### PR TITLE
Install solidus without javascript compilers (webpacker)

### DIFF
--- a/getting-started/what-is-solidus.md
+++ b/getting-started/what-is-solidus.md
@@ -27,10 +27,10 @@ For maximum flexibility, you can decide you just want to install specific gems a
 If you don't have an existing Ruby on Rails application yet, simply create one:
 
 ```bash
-$ rails new amazing_store --skip-webpack-install
+$ rails new amazing_store --skip-javascript
 ```
 
-Solidus doesn't require Webpacker, which is why we are skipping it. You are still free to install it and use it in your store, though.
+Solidus doesn't require the JavaScript compiler shipped with Rails by default (Webpacker). You are still free to install it and use it in your store, though.
 
 Once you have generated your new Rails application, you can proceed as if you were installing Solidus [in an existing app](what-is-solidus.md#in-an-existing-app).
 


### PR DESCRIPTION
Using `--skip-webpack-install` is only preventing the Rails install generator from 
running `webacker:install`, but the `webpacker` gem is still added to the Gemfile.

Ref: https://github.com/rails/rails/issues/35484

In the context of a fresh app that uses the bare minimum set of tools to run Solidus
we don't need that. People can still add it later if needed.