### PR TITLE
Minor typo and clarity fixes

### DIFF
--- a/getting-started/deployment.md
+++ b/getting-started/deployment.md
@@ -2,7 +2,7 @@
 
 ## Deploying to the cloud
 
-Deploying a Solidus application to production is not different from deploying any other Rails application. In this section, we'll cover some popular options for deploying Solidus and a few additional caveats.
+Deploying a Solidus application to production is no different from deploying any other Rails application. In this section we'll cover some popular options for deploying Solidus and a few additional caveats.
 
 ### Heroku
 
@@ -42,17 +42,17 @@ This section still needs to be written.
 
 ## External dependencies
 
-When deploying a Solidus store, there are a few external dependencies you will also need to install, or may decide to install in order to make your application more resilient and easier to scale.
+When deploying a Solidus store, there are a few external dependencies that must be installed. There are also some optional dependencies you may decide to install in order to make your application more resilient and easier to scale.
 
 ### File storage
 
 {% hint style="warning" %}
-Paperclip [has been deprecated](https://github.com/thoughtbot/paperclip#deprecated) in favor of Rails' native [ActiveStorage](https://guides.rubyonrails.org/active_storage_overview.html) library. Solidus already supports ActiveStorage but, due to limitations in ActiveStorage itself, you will not be able to use it until Rails 6.1 is released with support for [public URLs](https://edgeguides.rubyonrails.org/active_storage_overview.html#public-access).
+Paperclip [has been deprecated](https://github.com/thoughtbot/paperclip#deprecated) in favor of Rails' native [ActiveStorage](https://guides.rubyonrails.org/active_storage_overview.html) library. Solidus already supports ActiveStorage, but due to limitations in ActiveStorage itself you will not be able to use it until Rails 6.1 is released with support for [public URLs](https://edgeguides.rubyonrails.org/active_storage_overview.html#public-access).
 {% endhint %}
 
-When you run Solidus locally or on a single node, any files you upload \(product images, taxon icons etc.\) are stored on the filesystem. While this works great in development, it's not a viable option when deploying to cloud platforms, where clustering would cause files in one node not to be accessible by all other nodes, or files to disappear when a node reboots because of [ephemeral filesystems](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem).
+When you run Solidus locally or on a single node, any files you upload \(product images, taxon icons etc.\) are stored on the filesystem. While this works great in development, it's not a viable option when deploying to cloud platforms where clustering may cause files in one node not to be accessible by all other nodes. You may also find that files disappear when a node reboots because of [ephemeral filesystems](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem).
 
-When running your store in production, you will have to rely on a file storage service such as [Amazon S3](https://aws.amazon.com/it/s3/) or [Microsoft Azure Storage Service](https://azure.microsoft.com/en-us/services/storage/). Files will be uploaded to the storage service, which will also handle all concerns of high availability, security and distribution, and retrieved via a public URL.
+When running your store in production, you will have to rely on a file storage service such as [Amazon S3](https://aws.amazon.com/it/s3/) or [Microsoft Azure Storage Service](https://azure.microsoft.com/en-us/services/storage/). Files will be uploaded to the storage service, which will also handle concerns such as high availability, security and distribution, and retrieval via a public URL.
 
 Solidus supports storage services out of the box by integrating with the [Paperclip](https://github.com/thoughtbot/paperclip) gem. In order to configure Paperclip, just create an initializer like the following:
 
@@ -77,19 +77,19 @@ If you're not using S3, Paperclip provides support for the most popular storage 
 
 ### Cache store
 
-Solidus employs [fragment caching](https://guides.rubyonrails.org/caching_with_rails.html#fragment-caching) and [low-level caching](https://guides.rubyonrails.org/caching_with_rails.html#low-level-caching) pretty extensively throughout the storefront and API views. By default, Rails uses an in-memory cache adapter in production, which will essentially make all caching useless, since the cache is not shared across nodes of your application.
+Solidus employs [fragment caching](https://guides.rubyonrails.org/caching_with_rails.html#fragment-caching) and [low-level caching](https://guides.rubyonrails.org/caching_with_rails.html#low-level-caching) extensively throughout the storefront and API views. By default, Rails uses an in-memory cache adapter in production. This essentially makes all caching useless if you are running Solidus across multiple nodes, since the cache is not shared across instances.
 
-Instead of the default adapter, you should instead rely on an actual caching system. Popular options in the Rails ecosystem are [memcached](https://memcached.org/) and [Redis](https://redis.io/).
+Therefore, instead of the default adapter you should instead rely on an actual caching system. Popular options in the Rails ecosystem are [memcached](https://memcached.org/) and [Redis](https://redis.io/).
 
-The procedure for configuring your cache store with Solidus is not different from doing it in a regular Rails application, so simply refer to the [Rails caching guide](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore) for more details and recommendations on how to properly set up your caching server.
+The procedure for configuring your cache store with Solidus is no different from doing it in a regular Rails application. Refer to the [Rails caching guide](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore) for more details and recommendations on how to properly set up your caching server.
 
 ### Async operations
 
-Solidus schedules certain time-intensive operations in the background, to provide faster feedback to the user and avoid blocking the Web process for too long. The most common examples are transactional emails: when an email needs to be delivered to the user, Solidus will enqueue the operation rather than executing it immediately. This operation will then be run in the background by [ActiveJob](https://guides.rubyonrails.org/active_job_basics.html).
+Solidus schedules certain time-intensive operations in the background. This provides faster feedback to the user and avoids blocking the Web process for too long. The most common examples are transactional emails. When an email needs to be delivered to the user, Solidus will enqueue the operation rather than executing it immediately. This operation will then be run in the background by [ActiveJob](https://guides.rubyonrails.org/active_job_basics.html).
 
-The default ActiveJob adapter is [Async](https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html), which uses an in-process thread pool to schedule jobs. While a good choice for local development and testing, this is a pretty poor option for production deployments, because any pending jobs are dropped when the process restarts \([Heroku restarts dynos automatically every 24 hours](https://devcenter.heroku.com/articles/dynos#automatic-dyno-restarts), for instance\).
+The default ActiveJob adapter is [Async](https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html), which uses an in-process thread pool to schedule jobs. While Async is a good choice for local development and testing, it is a poor option for production deployments, as any pending jobs are dropped when the process restarts \([Heroku restarts dynos automatically every 24 hours](https://devcenter.heroku.com/articles/dynos#automatic-dyno-restarts), for instance\).
 
-Instead, you should use a production-grade queue such as [Sidekiq](https://github.com/mperham/sidekiq), which uses Redis for storing and retrieving the jobs under the hood. Using Sidekiq with ActiveJob is pretty simple. First of all, install Sidekiq by adding it to your `Gemfile`:
+Instead, you should use a production-grade queue such as [Sidekiq](https://github.com/mperham/sidekiq), which uses Redis for storing and retrieving your application's jobs under the hood. Using Sidekiq with ActiveJob is simple. First of all, install Sidekiq by adding it to your `Gemfile`:
 
 {% code title="Gemfile" %}
 ```ruby
@@ -121,15 +121,15 @@ That's it! Solidus will now use Sidekiq and Redis for all asynchronous processin
 
 ### Content delivery network
 
-It is strongly recommended to serve static assets via a [Content Delivery Network \(CDN\)](https://it.wikipedia.org/wiki/Content_Delivery_Network) rather than your own application. CDNs are a relatively simple and efficient way to instantaneously boost the performance of your application and are widely used in Web development.
+It is strongly recommended to serve static assets via a [Content Delivery Network \(CDN\)](https://it.wikipedia.org/wiki/Content_Delivery_Network) rather than your own application. CDNs are a relatively simple and efficient way to instantaneously boost the performance of your application, and are widely used in Web development.
 
-Like for many other tasks, configuring a CDN for Solidus is the same as configuring it for a regular Rails application, so you can refer to the Rails guides on [configuring a CDN](https://guides.rubyonrails.org/asset_pipeline.html#cdns).
+As with many other tasks, configuring a CDN for Solidus is the same as configuring it for a regular Rails application, so you can refer to the Rails guides on [configuring a CDN](https://guides.rubyonrails.org/asset_pipeline.html#cdns).
 
 There are many reliable CDNs, with the most popular being [Amazon CloudFront](https://aws.amazon.com/it/cloudfront/).
 
 ### Email delivery
 
-In order to send emails, Solidus needs a valid SMTP server. While you could use your domain registrar's mail server, it is usually recommended to use a more robust and feature-complete solution that will also provide useful insights and business metrics such as your deliverability, open and click-through rates.
+In order to send emails, Solidus needs a valid SMTP server. While you could use your domain registrar's mail server, it is usually recommended to use a more robust and feature-complete solution that will also provide useful insights and business metrics like deliverability, open, and click-through rates.
 
 [SendGrid](https://sendgrid.com/), [Mailgun](https://www.mailgun.com/) and [Mailchimp](https://mailchimp.com/features/transactional-email/) are all very good, battle-tested solutions for delivering transactional emails to your customers, but you are free to use any other service you wish.
 

--- a/getting-started/extensions.md
+++ b/getting-started/extensions.md
@@ -2,9 +2,9 @@
 
 ## When to use extensions
 
-When you first install Solidus, you will notice that the platform is complete but quite lean: there aren't any toggles to enable shiny additional features. You get what you need to start an online store, and nothing more. This is by design: we know that each brand's business domain and USP are unique, and that they require a unique implementation approach. With that said, we also know that it isn't always smart to reinvent the wheel, especially when you're dealing with a common problem that's already been solved.
+When you first install Solidus, you will notice that the platform is complete but quite lean. There aren't any toggles to enable shiny additional features. You get what you need to start an online store, and nothing more. This is by design. We know that each brand's business domain and USP are unique, and that they require a unique implementation approach. With that said, we also know that it isn't always smart to reinvent the wheel, especially when you're dealing with a common problem that's already been solved.
 
-The easiest and quickest way to augment the functionality of your store is through _extensions_. These are gems or full-fledged Rails engines that provide additional functionality for Solidus by extending and overriding parts of the core. The Solidus ecosystem has a lot of extensions for the most disparate tasks: there are extensions that add support for new payment providers or 3PL integrations, extensions that enhance your store with social features and many, many more to choose from.
+The easiest and quickest way to augment the functionality of your store is through _extensions_. These are gems or full-fledged Rails engines that provide additional functionality for Solidus by extending and overriding parts of the core. The Solidus ecosystem has a lot of extensions for many disparate tasks. There are extensions that add support for new payment providers or 3PL integrations, extensions that enhance your store with social features and many, many more to choose from.
 
 In general, if there's already an extension that solves your problem, you should evaluate it before attempting to roll your own solution. Reusing the work of the community will not only save you the effort of a custom implementation, but will also make the community stronger.
 
@@ -72,9 +72,9 @@ The order gems appear in your `Gemfile` is important in the case of Solidus exte
 
 ## Staying up-to-date
 
-Just like the core, extensions are constantly updated to add new features, enhance existing functionality, fix bugs and add compatibility with new Solidus versions. It's extremely important to keep your extensions up to date with the same diligence you reserve to the rest of your application, and having a clear process in place for continuously updating them. The easier it is to update extensions, the likelier it is you will be doing it early and often.
+Just like the core, extensions are constantly updated to add new features, enhance existing functionality, fix bugs and add compatibility with new Solidus versions. It's extremely important to keep your extensions up to date with the same diligence you reserve for the rest of your application. You should have a clear process in place for continuously updating extensions. The easier it is to update extensions, the likelier it is you will be doing it early and often.
 
-The recommended approach is to write automated tests for any functionality added by extensions to your store. While extensions do have their own test suites, you cannot always predict how an extension will interact with your own customizations or with other extensions, and it's always best to test functionality in integration and in the context of your own app.
+The recommended approach is to write automated tests for any functionality added by extensions to your store. While extensions may have their own test suites, you cannot always predict how an extension will interact with your store's customizations or with other extensions. Furthermore, it's always best to test functionality in integration and in the context of your own app.
 
 It's also recommended NOT to add any version constraints to extensions in your `Gemfile`. Instead, rely on your tests to ensure nothing's broken after an update. Ideally, the update process should be as simple as running the following commands:
 

--- a/getting-started/what-is-solidus.md
+++ b/getting-started/what-is-solidus.md
@@ -4,21 +4,21 @@
 
 Solidus requires the following software on the host to run properly:
 
-* [Ruby](https://ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby branch.
-* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby branch.
+* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other relational databases should work as well.
 * [ImageMagick](http://imagemagick.org/script/download.php): this is needed for manipulating product images and other assets.
 
 ## Gem ecosystem
 
-Solidus has been designed as an ecosystem of independent libraries \(_gems_, in the Ruby world\) that work well in isolation, but collaborate to give you an amazing eCommerce experience when used together. A standard Solidus installation is comprised of the following gems:
+Solidus has been designed as an ecosystem of independent libraries \(_gems_, in the Ruby world\) that work well in isolation, but collaborate to give you an amazing eCommerce experience when used together. A standard Solidus installation is composed of the following gems:
 
 * [solidus\_core](https://github.com/solidusio/solidus/tree/master/core): provides the core data models and eCommerce business logic. This is the bare minimum for a Solidus install.
 * [solidus\_backend](https://github.com/solidusio/solidus/tree/master/backend): provides the standard Solidus backend, a powerful administrative UI you can use to manage your Solidus store.
 * [solidus\_frontend](https://github.com/solidusio/solidus/tree/master/frontend): provides the standard Solidus storefront along with helpers to build your own.
 * [solidus\_api](https://github.com/solidusio/solidus/tree/master/api): provides the Solidus REST API. The API is required by the backend, but you may also use it for your own purposes \(e.g. for JS interactions in the storefront\).
 
-For maximum flexibility, you can decide you just want to install specific gems and built the rest of the functionality yourself. Or, if you want the full-fledged Solidus experience, you can install the [solidus](https://github.com/solidusio/solidus) gem, which ties them all together and will give you a complete store. This is the approach we'll be following in this guide.
+For maximum flexibility, you can decide you just want to install specific gems and build the rest of the functionality yourself. Or, if you want the full-fledged Solidus experience, you can install the [solidus](https://github.com/solidusio/solidus) gem, which ties them all together and will give you a complete store. This is the approach we'll be following in this guide.
 
 ## Installing Solidus
 
@@ -76,21 +76,21 @@ When upgrading, look at the [changelog](https://github.com/solidusio/solidus/blo
 
 Solidus' policy on Ruby and Ruby on Rails support is fairly simple: each release supports up to the oldest Ruby and Rails versions that are still maintained.
 
-Solidus 2.10, for instance, introduced support for Rails 6.0, but it also works with Rails 5.2. As for Ruby, it works with Ruby 2.4 and later, because 2.4 was the oldest maintained version at the time of release. However, you cannot use Rails 6 with Ruby 2.4, which means you will have to upgrade to at least Ruby 2.5 if you want to use Solidus with Rails 6.
+Solidus 2.10, for instance, introduced support for Rails 6.0, but it also works with Rails 5.2. As for Ruby, Solidus works with Ruby 2.4 and later, because 2.4 was the oldest maintained version at the time of release. However, you cannot use Rails 6 with Ruby 2.4, which means you will have to upgrade to at least Ruby 2.5 if you want to use Solidus with Rails 6.
 
 When you upgrade Solidus, you should also make sure to upgrade your Ruby and Rails versions to the newest possible versions. Ruby upgrades are usually pretty smooth, while Rails provides amazing [upgrade guides](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) you can follow.
 
 ### Upgrading dependencies
 
-Solidus is just a Rails engine that runs as part of your application, so you should still take care of regularly upgrading any other dependencies in addition to Solidus. There are tools that can help you stay on top of version updates, such as [Dependabot](https://dependabot.com/), but in general the best tool you can employ is a solid suite of automated unit and integration tests that verify the behavior of your application after an upgrade.
+Solidus is just a Rails engine that runs as part of your application, so you should still take care to regularly upgrade any other dependencies in addition to Solidus. There are tools that can help you stay on top of version updates, such as [Dependabot](https://dependabot.com/), but in general the best tool you can employ is a solid suite of automated unit and integration tests that verify the behavior of your application after an upgrade.
 
 ### Dealing with deprecations
 
 {% hint style="warning" %}
-While it can be tempting to leave calls to deprecated APIs in place and wait for their removal before fixing them, this approach will come back to haunt you when you upgrade to a new major version and find that you need to update tens of method calls that don't work anymore.
+While it can be tempting to leave calls to deprecated APIs in place and wait for their removal before fixing them, this approach will come back to haunt you when you upgrade to a new major version and find that you need to update dozens of method calls that don't work anymore.
 {% endhint %}
 
-A special mention goes to deprecations, and how to handle them correctly. The recommended approach is to fix deprecation warnings as soon as they arise. When you upgrade Solidus, run your entire test suite and copy all deprecation warnings to a separate file. In Bash, you can easily do it by running this command from your app's root:
+It's particularly important to understand how to handle deprecations correctly. The recommended approach is to fix deprecation warnings as soon as they arise. When you upgrade Solidus, run your entire test suite and copy all deprecation warnings to a separate file. In Bash, you can easily do it by running this command from your app's root:
 
 ```bash
 $ bundle exec rspec 2>deprecations.txt
@@ -102,7 +102,7 @@ This will save all Solidus deprecations to the `deprecations.txt` file. You will
 $ cat deprecations.txt | sort | uniq
 ```
 
-This will output a de-duplicated list of deprecations in your code. Once you have this, just go through the deprecations one by one and fix them, then run your test suite again to ensure your app doesn't contain any deprecated code anymore.
+This will output a de-duplicated list of deprecations in your code. Once you have this, just go through the deprecations one by one and fix them. Then run your test suite again to ensure your app doesn't contain any deprecated code.
 
 {% hint style="info" %}
 In some cases, deprecated code may come from Solidus extensions and not your own app, meaning you can't fix the deprecation yourself. When this happens, you can open an issue in the extension's repository to let the maintainer know that they need to update their extension.


### PR DESCRIPTION
This commit fixes some minor grammatical typos and tries to improve readability. Some longer sentences have been split into multiple sentences to make them easier to scan and parse.