### PR TITLE
Update install instructions to Solidus 2.11

### DIFF
--- a/getting-started/what-is-solidus.md
+++ b/getting-started/what-is-solidus.md
@@ -43,7 +43,6 @@ If you have an existing Ruby on Rails application, installing Solidus is fairly 
 # ...
 
 gem 'solidus'
-gem 'solidus_auth_devise'
 ```
 {% endcode %}
 
@@ -51,7 +50,7 @@ Then, install the bundle and configure Solidus:
 
 ```bash
 $ bundle install
-$ bin/rails generate spree:install
+$ bin/rails generate solidus:install
 ```
 
 The installer will prompt you for an admin email and password. You can leave the default \(email: admin@example.com, password: test123\) or enter your own.


### PR DESCRIPTION
This PR updates the instructions for installing Solidus from version 2.10 (and under) to 2.11.