### PR TITLE
Update installation guide and references to solidus_starter_frontend

### DIFF
--- a/docs/advanced-solidus/custom-authentication.mdx
+++ b/docs/advanced-solidus/custom-authentication.mdx
@@ -22,7 +22,8 @@ In order to use a custom user model, your model should have:
 * **An integer `id` column:** Solidus uses integers for all foreign keys, so you need to use integer IDs in your user
   model. You may use other types of IDs by changing the types of the foreign key columns, but this is generally
   discouraged.
-* **A `password` attribute:** This is needed if you use the stock `solidus_frontend` or `solidus_backend` gems. You can
+* **A `password` attribute:** This is needed if you use
+  `solidus_starter_frontend`, `solidus_frontend` or `solidus_backend`. You can
   implement the attribute however you see fit.
 
 This is all you need for now. The rest of the requirements will be implemented in the next steps!
@@ -43,8 +44,9 @@ This will do the following:
 * Generate a migration to add some required columns to the custom model's table.
 * Set `Spree.user_class` to your custom model's class name, so that Solidus knows to use it in associations and
   throughout the store.
-* Implement some authentication helpers required by `solidus_backend` and `solidus_frontend`
-  in `lib/spree/authentication_helpers.rb`.
+* Implement some authentication helpers required by `solidus_backend`,
+  `solidus_starter_frontend` and `solidus_frontend` in
+  `lib/spree/authentication_helpers.rb`.
 
 At this point, you'll need to migrate your database to add the new columns:
 
@@ -83,8 +85,9 @@ $ rails db:migrate
 
 #### spree\_current\_user helper <a id="spree-em-current-em-user"></a>
 
-If you use the stock `solidus_frontend` or `solidus_backend` gems, you need to provide a `spree_current_user` helper
-method in your `ApplicationController`:
+If you use `solidus_starter_frontend`, `solidus_frontend` or `solidus_backend`,
+you need to provide a `spree_current_user` helper method in your
+`ApplicationController`:
 
 ```ruby title="app/controllers/application\_controller.rb"
 class ApplicationController < ActionController::Base
@@ -103,8 +106,9 @@ end
 
 #### Add authentication helpers <a id="add-authentication-helpers"></a>
 
-If you use the stock `solidus_frontend` or `solidus_backend` gems, you need to provide authentication helpers so that
-users can sign up, log in, and log out:
+If you use `solidus_starter_frontend`, `solidus_frontend` or `solidus_backend`,
+you need to provide authentication helpers so that users can sign up, log in,
+and log out:
 
 ```ruby title="app/controllers/application\_controller.rb"
 class ApplicationController < ActionController::Base

--- a/docs/getting-started/installing-solidus.mdx
+++ b/docs/getting-started/installing-solidus.mdx
@@ -30,11 +30,16 @@ together. A standard Solidus installation is composed of the following gems:
 models and eCommerce business logic. This is the bare minimum for a Solidus install.
 * [solidus\_backend](https://github.com/solidusio/solidus/tree/master/backend): provides the
 standard Solidus backend, a powerful administrative UI you can use to manage your Solidus store.
-* [solidus\_frontend](https://github.com/solidusio/solidus/tree/master/frontend): provides the
 standard Solidus storefront along with helpers to build your own.
 * [solidus\_api](https://github.com/solidusio/solidus/tree/master/api): provides the Solidus REST
 API. The API is required by the backend, but you may also use it for your own purposes (e.g. for
 JS interactions in the storefront).
+
+Besides, Solidus aims to be agnostic of the storefront. We provide
+[solidus\_starter\_frontend](https://github.com/solidusio/solidus_starter_frontend)
+as a bootstrap solution from which a tailored store can be built. Otherwise,
+you can create your storefront from scratch using whatever technology you
+prefer.
 
 For maximum flexibility, you can decide you just want to install specific gems and build the rest of
 the functionality yourself. Or, if you want the full-fledged Solidus experience, you can install
@@ -68,11 +73,19 @@ $ bin/rails generate solidus:install
 ```
 
 The installer will prompt you on a few questions before completing the
-installation. It will ask if you would like to use the default authentication
-solution, [Devise](https://github.com/heartcombo/devise), or your implement
-your own. Finally, you will be prompted for an admin email and password. You
-can leave the default (email: admin@example.com, password: test123) or enter
-your own.
+installation:
+
+- It will ask if you would like to use the default authentication solution,
+[Devise](https://github.com/heartcombo/devise), or implement your own.
+- It will also prompt you to choose which storefront you want to install. We
+recommend picking
+[solidus\_starter\_frontend](https://github.com/solidusio/solidus_starter_frontend)
+to quickly get up & running. You might need to choose the deprecated
+[solidus\_frontend](https://github.com/solidusio/solidus_frontend) if you want
+to use an extension that still relies on it. There's also the option to choose
+no frontend.
+- Finally, you will be prompted for an admin email and password. You can leave
+the default (email: admin@example.com, password: test123) or enter your own.
 
 Once the installation has completed, you can now start your Rails server:
 

--- a/docs/getting-started/installing-solidus.mdx
+++ b/docs/getting-started/installing-solidus.mdx
@@ -67,15 +67,12 @@ $ bundle add 'solidus'
 $ bin/rails generate solidus:install
 ```
 
-The installer will prompt you on a few questions before completing the installation. First it will
-ask if you would like to use the default authentication
-solution, [Devise](https://github.com/heartcombo/devise), or your implement your own. Next it will
-ask what payment service you would like to install with solidus.Currently, Solidus comes packaged
-with [Paypal](https://developer.paypal.com/home) as the default and only option. Other integrated
-services that you tie into your application can be found and in the payment section
-of [Solidus extensions](https://solidus.io/extensions/). If you want to skip installing a payment
-service, just type 'none'. Finally, you will be prompted for an admin email and password. You can
-leave the default (email: admin@example.com, password: test123) or enter your own.
+The installer will prompt you on a few questions before completing the
+installation. It will ask if you would like to use the default authentication
+solution, [Devise](https://github.com/heartcombo/devise), or your implement
+your own. Finally, you will be prompted for an admin email and password. You
+can leave the default (email: admin@example.com, password: test123) or enter
+your own.
 
 Once the installation has completed, you can now start your Rails server:
 

--- a/docs/getting-started/upgrading-solidus.mdx
+++ b/docs/getting-started/upgrading-solidus.mdx
@@ -129,11 +129,11 @@ defaults, you can flip the version used in `spree.rb`'s `Spree.load_defaults` ca
 the `new_solidus_defaults.rb` file altogether.
 
 Internally, `Spree.load_defaults` is a shortcut that forwards the same method to the configuration
-object for every available Solidus component: core, backend, frontend & API. You'll see that
-the `#load_defaults` call, with the previous version as argument, is disassembled into the
-individual components in `new_solidus_defaults.rb`. It gives you more fine-grained control as you
-can flag as done an individual component by updating its `#load_defaults` version when you're done
-with it.
+object for every available Solidus component: core, backend & API. You'll see
+that the `#load_defaults` call, with the previous version as argument, is
+disassembled into the individual components in `new_solidus_defaults.rb`. It
+gives you more fine-grained control as you can flag as done an individual
+component by updating its `#load_defaults` version when you're done with it.
 
 For instance, say that you're upgrading from Solidus 3.0 to 3.1, and three made-up defaults have
 changed:


### PR DESCRIPTION
PayPal is no longer an option in the installation script. See solidusio/solidus#4494.

Solidus Starter Frontend is now considered stable and it's installable from the main installation script. See solidusio/solidus#4490