### PR TITLE
Add searchbar powered by Algolia Docsearch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,6 +131,12 @@ const config = {
         darkTheme: darkCodeTheme,
         additionalLanguages: ["ruby", "erb"],
       },
+      algolia: {
+        appId: 'UBY09X99OB',
+        apiKey: '8ad55e50cbf0c0d82709597260065f36',
+        indexName: 'edgeguides',
+        contextualSearch: true
+      },
     }),
 };
 


### PR DESCRIPTION
This service is free for open source projects, thanks!

Some notes:

1. I enabled contextual search, this should allow us to have the search working when we'll have multiple versions of the guide published, let's revist when that happens.
2. For reference, I follewed this guide: https://docusaurus.io/docs/search and on that page, there's a section that describe how to style the search component. Might be useful in a while.

Please also note that I left keys and appID public. They are supposed to be public because they will be rendered in the final HTML, so no need of an ENV variable for them.


![Screenshot 2022-08-12 at 09 37 28@2x](https://user-images.githubusercontent.com/167946/184307433-d9d58eef-aee0-4c15-b88e-bc66f076ce70.png)
<img width="901" alt="Screenshot 2022-08-12 at 09 37 58@2x" src="https://user-images.githubusercontent.com/167946/184307479-072529d4-f1e0-4f60-86d9-a2c76e326424.png">

