### PR TITLE
Add guides for returns and a couple of related how-to guides

### DIFF
--- a/docs/advanced-solidus/returns.mdx
+++ b/docs/advanced-solidus/returns.mdx
@@ -94,6 +94,7 @@ either reimbursed or errored.
 ## How-to guides
 
 - [How to customize the default elibility: skipping RMAs][how-to-customize-default-eligibility]
+- [How to modify valid exchange items][how-to-modify-valid-exchange-items]
 
 [return-authorization]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_authorization.rb
 [return-item]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item.rb
@@ -101,3 +102,4 @@ either reimbursed or errored.
 [customer-return]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/customer_return.rb
 [reimbursement]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/reimbursement.rb
 [how-to-customize-default-eligibility]: /how-tos/how_to_customize_the_default_eligibility_in_returns_skipping_rmas.mdx
+[how-to-modify-valid-exchange-items]: /how-tos/how_to_modify_valid_exchange_items_in_returns.mdx

--- a/docs/advanced-solidus/returns.mdx
+++ b/docs/advanced-solidus/returns.mdx
@@ -95,6 +95,7 @@ either reimbursed or errored.
 
 - [How to customize the default elibility: skipping RMAs][how-to-customize-default-eligibility]
 - [How to modify valid exchange items][how-to-modify-valid-exchange-items]
+- [How to use custom logic to calculate refunds][how-to-use-custom-logic-to-calculate-refunds]
 
 [return-authorization]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_authorization.rb
 [return-item]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item.rb
@@ -103,3 +104,4 @@ either reimbursed or errored.
 [reimbursement]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/reimbursement.rb
 [how-to-customize-default-eligibility]: /how-tos/how_to_customize_the_default_eligibility_in_returns_skipping_rmas.mdx
 [how-to-modify-valid-exchange-items]: /how-tos/how_to_modify_valid_exchange_items_in_returns.mdx
+[how-to-use-custom-logic-to-calculate-refunds]: /how-tos/how_to_use_custom_logic_to_calculate_return_refunds.mdx

--- a/docs/advanced-solidus/returns.mdx
+++ b/docs/advanced-solidus/returns.mdx
@@ -1,0 +1,98 @@
+---
+sidebar_position: 8
+---
+
+# Returns
+
+This guide will go through what Solidus offers to manage the return of
+purchased items: the compensation of their cost in different ways or the
+exchange with other products.
+
+Sometimes things don't go as expected during an online transaction. Items can
+get damaged in their way, or the wrong product is shipped by error. Other
+times, companies have flexible return policies to remove friction in the
+payment step. In any case, e-commerce stores need a process to monitor returns
+and reliably support customers and administrators.
+
+## RMA: return authorizations
+
+The journey of a return usually begins with the buyer asking for it, whether
+via form or email. At that moment, the customer service can create an RMA
+(Return Merchandise Authorization) with a unique number that can be used as a
+reference for any further communication.
+
+In Solidus, an RMA is represented by the
+[`Spree::ReturnAuthorization`][return-authorization] model. It contains a
+number and other information like the stock location where items should be
+delivered or a memo for a free-text description.
+
+A `Spree::ReturnAuthorization` has an authorized state on creation, but it can
+be canceled if desired. We must note that, at this point, we're still dealing
+with user requests, not actual returns. A store can authorize a request and
+keep processing it, regardless of its final result (e.g., not ending up
+accepting a return), or it can cancel it for being invalid and not deserving
+further consideration.
+
+## Return items
+
+An RMA must reference one or more of the products a customer purchased. For
+instance, a user bought five cups, but one of them arrived damaged. Depending
+on the store policy, they might ask for a reimbursement or an exchange for
+another cup. At a later stage, the request will be approved, edited or denied.
+
+In Solidus, each return item is represented through a
+[`Spree::ReturnItem`][return-item] record. Notice that a `Spree::ReturnItem`
+instance is associated with a [`Spree::InventoryUnit`][inventory-unit]. That's
+the most concrete level of product identification in orders; i.e., orders can
+have several line items for different variants, and each line item may contain
+one or more. The inventory unit maps one to one to a physical (or digital, for
+what it's worth) object, such as a broken cup.
+
+A `Spree::ReturnItem` contains information about the requested reimbursement
+amount and how it should be processed (e.g., refund or store credit) or another
+unit with which the store should replace it.
+
+Finally, two status fields govern the lifecycle of an item to return:
+
+- The **acceptance status** controls the eligibility of the return per-se. Initially
+_pending_, it should end up _accepted_ in case of going forward.
+- The **reception status** marks whether the store has already received the
+returned package. In a standard scenario, it should transition from _awaiting_
+to _received_.
+
+## Customer returns
+
+Finally, after the return authorization has moved forward, it'll materialize in
+a customer return. At that point, a store will already have the returned items
+back. It might be that the customer support department rejected some of the
+requests or accepted all of them.
+
+In Solidus, that's represented by a [`Spree::CustomerReturn`][customer-return]
+record. Similar to RMAs, it's a simple model. It only contains an
+identification number and a stock location that is a final override of the
+RMA's proposal. Customer returns are flexible and not tied to a single return
+authorization. Because of that, `Spree::ReturnItem` belongs not only to
+`Spree::ReturnAuthorization` but also to `Spree::CustomerReturn`.
+
+## Reimbursements
+
+The final step is fulfilling the store obligations and performing the agreed
+reimbursement or exchange. The store will need another shipment with the new
+items in the latter case.
+
+[`Spree::Reimbursement`][reimbursement] takes care of wrapping everything up.
+It's associated with a `Spree::CustomerReturn`, but the system is flexible
+enough so that more than one can be created until all returned items have been
+processed.
+
+Typically, administrators can edit the returned item details, like the amount
+to refund, the article to use as a substitute, or if it should be marked as
+resellable. The system will also take care of creating a new shipment if
+needed. In the end, a new reimbursement record will be created with a state of
+either reimbursed or errored.
+
+[return-authorization]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_authorization.rb
+[return-item]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item.rb
+[inventory-unit]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/inventory_unit.rb
+[customer-return]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/customer_return.rb
+[reimbursement]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/reimbursement.rb

--- a/docs/advanced-solidus/returns.mdx
+++ b/docs/advanced-solidus/returns.mdx
@@ -91,8 +91,13 @@ resellable. The system will also take care of creating a new shipment if
 needed. In the end, a new reimbursement record will be created with a state of
 either reimbursed or errored.
 
+## How-to guides
+
+- [How to customize the default elibility: skipping RMAs][how-to-customize-default-eligibility]
+
 [return-authorization]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_authorization.rb
 [return-item]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item.rb
 [inventory-unit]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/inventory_unit.rb
 [customer-return]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/customer_return.rb
 [reimbursement]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/reimbursement.rb
+[how-to-customize-default-eligibility]: /how-tos/how_to_customize_the_default_eligibility_in_returns_skipping_rmas.mdx

--- a/docs/advanced-solidus/state-machines.mdx
+++ b/docs/advanced-solidus/state-machines.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 needs-diataxis-rewrite: true
 ---
 

--- a/docs/advanced-solidus/stock-and-fulfillment.mdx
+++ b/docs/advanced-solidus/stock-and-fulfillment.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 needs-diataxis-rewrite: true
 ---
 

--- a/docs/advanced-solidus/tax-calculation.mdx
+++ b/docs/advanced-solidus/tax-calculation.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 needs-diataxis-rewrite: true
 ---
 

--- a/docs/how-tos/_category_.json
+++ b/docs/how-tos/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "How-tos",
+  "position": 5,
+  "collapsible": false,
+  "collapsed": false
+}

--- a/docs/how-tos/how_to_customize_return_eligibility_rules_skipping_rmas.mdx
+++ b/docs/how-tos/how_to_customize_return_eligibility_rules_skipping_rmas.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 1
+---
+
+# How to customize return eligibility rules: skipping RMAs
+
+Solidus' [built-in process for returns][returns] is mighty and flexible, and
+even allows you to disable RMAs as a prerequisite to creating a customer
+return.
+
+Go ahead and create an order from the storefront. You must go through
+the entire checkout process, from adding items to the cart to confirming the
+payment.
+
+Next, you need to capture the payments in the system and perform the shipments.
+You can do it either from the admin panel or through the console. E.g.:
+
+```ruby
+order = Spree::Order.find_by_number('R723438584')
+order.payments.map(&:capture!)
+order.shipments.map(&:ship!)
+```
+
+Let us go to the heart of the matter. When you add return items to a customer's
+return, Solidus checks whether they are eligible for being returned. By
+default, it uses
+[`Spree::ReturnItem::EligibilityValidator::Default`][eligibility-validator-default].
+Even if you can [replace it altogether][configure-eligibility-validator], the
+default validator is flexible enough to allow us to skip only the requirement
+for an RMA.
+
+Take a look at the stack of steps that `EligibilityValidator::Default` calls:
+
+```ruby title="core/app/models/spree/return_item/eligibility_validator/default.rb"
+# ...
+self.permitted_eligibility_validators = [
+  ReturnItem::EligibilityValidator::OrderCompleted,
+  ReturnItem::EligibilityValidator::TimeSincePurchase,
+  ReturnItem::EligibilityValidator::RMARequired,
+  ReturnItem::EligibilityValidator::InventoryShipped,
+  ReturnItem::EligibilityValidator::NoReimbursements
+]
+# ...
+```
+
+Let's use the Solidus initializer to remove the unwanted one:
+
+```ruby title="config/initializers/spree.rb"
+# ...
+Rails.application.config.to_prepare do
+  ::Spree::ReturnItem::EligibilityValidator::Default.permitted_eligibility_validators.delete(
+    ::Spree::ReturnItem::EligibilityValidator::RMARequired
+  )
+end
+# ...
+```
+
+And that's it! You can now simplify the return flow by creating customer
+returns without going through a previous authorization. You can go ahead and
+check it out in the admin panel.
+
+[returns]: /advanced-solidus/returns.mdx
+[eligibility-validator-default]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item/eligibility_validator/default.rb
+[configure-eligibility-validator]: https://github.com/solidusio/solidus/blob/008192cd82dc9e8c270b47782624172ac02b3552/core/app/models/spree/return_item.rb#L14

--- a/docs/how-tos/how_to_modify_valid_exchange_items_in_returns.mdx
+++ b/docs/how-tos/how_to_modify_valid_exchange_items_in_returns.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 2
+---
+
+# How to modify valid exchange items in returns
+
+When customers perform a [return][returns], they can be presented with options
+to exchange the corresponding item. We'll see how we can modify which variants are
+prompted as eligible.
+
+To begin with, you can go through the checkout process in the storefront and
+create a completed order. As we need to perform a return, we must capture its
+payments in the system and mark the shipments as delivered. You can do it in
+the backend or through the console:
+
+```ruby
+order = Spree::Order.find_by_number('R723438584')
+order.payments.map(&:capture!)
+order.shipments.map(&:ship!)
+```
+
+If you go now to the backend and try to create a new RMA for that order, you'll
+see that variants for the same product are shown to the user as valid
+exchanges. That's because, by default,
+[`Spree::ReturnItem::ExchangeVariantEligibility::SameProduct`][same-product] is
+[used as the engine][configure-exchange-variant-engine].
+
+Let's be more strict and leverage the default engine to restrict exchanges to
+those variants of the same product that are not heavier than the original. We
+need to follow the same API used by the built-in engines.
+
+```ruby title="app/services/amazing_store/return_item/exchange_variant_eligibility/same_product_not_heavier.rb"
+# frozen_string_literal: true
+
+module AmazingStore
+  module ReturnItem
+    module ExchangeVariantEligibility
+      module SameProductNotHeavier
+        def self.eligible_variants(variant, stock_locations: nil)
+          Spree::ReturnItem::ExchangeVariantEligibility::SameProduct.
+            eligible_variants(variant, stock_locations: stock_locations).
+            where(weight: ..variant.weight)
+        end
+      end
+    end
+  end
+end
+```
+
+Lastly, we need to tell Solidus to use our module by default. We can configure
+it in the Solidus initializer:
+
+```ruby title="config/initializers/spree.rb"
+# ...
+Rails.application.config.to_prepare do
+  ::Spree::ReturnItem.exchange_variant_engine = AmazingStore::ReturnItem::ExchangeVariantEligibility::SameProductNotHeavier
+end
+# ...
+```
+
+Restart the server and check it out! If you go back to the admin panel, you'll
+see that only lighter variants are now presented to the user.
+
+[returns]: /advanced-solidus/returns.mdx
+[configure-exchange-variant-engine]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item.rb#L22
+[same-product]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb

--- a/docs/how-tos/how_to_use_custom_logic_to_calculate_return_refunds.mdx
+++ b/docs/how-tos/how_to_use_custom_logic_to_calculate_return_refunds.mdx
@@ -1,0 +1,81 @@
+---
+sidebar_position: 3
+---
+
+# How to use custom logic to calculate return refunds
+
+We'll see how to customize the refund amount customers get when they perform a
+[return][returns]. Solidus performs full-amount refunds by default, but we can
+change it easily.
+
+We need a completed order, with payments captured and shipments delivered. Go
+through the checkout process and fulfill those conditions in the admin or
+console:
+
+```ruby
+order = Spree::Order.find_by_number('R723438584')
+order.payments.map(&:capture!)
+order.shipments.map(&:ship!)
+```
+
+You can go to the admin panel and check how the total amount for each inventory
+unit is presented by default when creating a new RMA for that order. That's the
+logic done by the [default return calculator][refund-calculator-default], which
+is [configured][configure-refund-calculator] in the return item model.
+
+Sometimes, though, stores need a stricter policy. Imagine that the full refund
+is only granted during the first week after placing the order. During the
+second week, there's a 25% penalty; beyond that, only 50% of the item's price
+is refunded.
+
+We can create our custom refund calculator accounting for those requirements
+while we can still lean on the default implementation:
+
+```ruby title="app/services/amazing_store/calculator/returns/with_penalty.rb"
+# frozen_string_literal: true
+
+module AmazingStore
+  module Calculator
+    module Returns
+      class WithPenalty < Spree::Calculator::Returns::DefaultRefundAmount
+        def compute(return_item)
+          default = super
+          case days_since_order(return_item)
+          when 0..7
+            default
+          when 8..14
+            default * 0.75
+          else
+            default * 0.5
+          end
+        end
+
+        private
+
+        def days_since_order(return_item)
+          (Date.today - return_item.inventory_unit.order.created_at.to_date).to_i
+        end
+      end
+    end
+  end
+end
+```
+
+We need to configure the returns item model to enable our calculator. Let's
+leverage the Solidus' initializer for that:
+
+```ruby title="config/initializers/spree.rb"
+# ...
+Rails.application.config.to_prepare do
+  ::Spree::ReturnItem.refund_amount_calculator = AmazingStore::Calculator::Returns::WithPenalty
+end
+# ...
+```
+
+That's it! Restart the server and check it out yourself. You might want to
+manually update the order's `:created_at` field to test the different possible
+situations.
+
+[returns]: /advanced-solidus/returns.mdx
+[refund-calculator-default]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/calculator/returns/default_refund_amount.rb
+[configure-refund-calculator]: https://github.com/solidusio/solidus/blob/31187cec36ccefca33406d5ffb5914db3eca78f2/core/app/models/spree/return_item.rb#L30


### PR DESCRIPTION
This PR adds documentation about the returns system in Solidus, plus a couple of related how-to guides:

- How to skip RMAs in returns
- How to modify valid exchanges in returns

Please tell me if you think another how-to guide is essential. There are just too many things to cover in this initial spike :slightly_smiling_face: 

I'm also using it as a POC for adopting the [Diátaxis](https://diataxis.fr) framework (ref. #60):

- My idea is to have high-level explanations for different Solidus sub-systems or concepts.
- Related how-to guides are listed on the explanation page.
- Nonetheless, how-to guides are hierarchically at the same level as explanations. That's because a single how-to guide can apply to different sub-systems/concepts, and users can find them more quickly this way.
- Explanations will be helpful during study time.
- When something needs to be done at work, the how-to guides are quick recipes that go straight to the point.
- A great benefit is how easy it can be for contributors to add new how-to guides. They don't need to try to make it fit within a surrounding narrative. They're short and standalone.
- That goes without prejudice to introducing comprehensive tutorials that go into detail for a given need.
- When it comes to references, at this point, I don't see it as the guide's responsibility but something that should go in the code documentation (RDoc).

Please, let me know what you think. I'll happily rearrange it to the structure that the team finds more suitable.