### PR TITLE
Add a link to the legacy guide in the 404 page

### DIFF
--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+export default function NotFound() {
+  return (
+    <>
+      <PageMetadata
+        title={translate({
+          id: 'theme.NotFound.title',
+          message: 'Page Not Found',
+        })}
+      />
+      <Layout>
+        <main className="container margin-vert--xl">
+          <div className="row">
+            <div className="col col--6 col--offset-3">
+              <h1 className="hero__title">
+                <Translate
+                  id="theme.NotFound.title"
+                  description="The title of the 404 page">
+                  Page Not Found
+                </Translate>
+              </h1>
+              <p>
+                <Translate
+                  id="theme.NotFound.p1"
+                  description="The first paragraph of the 404 page">
+                  We could not find what you were looking for.
+                </Translate>
+              </p>
+              <p>
+                <Translate
+                  id="theme.NotFound.p2"
+                  description="The 2nd paragraph of the 404 page">
+                  Please contact the owner of the site that linked you to the
+                  original URL and let them know their link is broken.
+                </Translate>
+              </p>
+              <p>
+                <b>
+                  Are you looking for the legacy guides? They have been
+                  moved <a target="_blank" href="https://legacy-guides.solidus.io">here</a>.
+                  </b>
+              </p>
+            </div>
+          </div>
+        </main>
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

This will help people with broken links.

The `NotFound` component has been swizzled following the [documentation](https://docusaurus.io/docs/swizzling#swizzling-theme-components):

```
npm run swizzle @docusaurus/theme-classic NotFound
```

## Checklist

- ~[ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.~
- [ ] I have verified that the preview environment works correctly.
