### PR TITLE
Fix primary color for dark theme mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -10,7 +10,7 @@
 }
 
 [data-theme='dark'] {
-    --ifm-color-primary: #dee5f2;
+    --ifm-color-primary: #3c76f0;
     --ifm-color-primary-dark: #bdcbe5;
     --ifm-color-primary-darker: #acbede;
     --ifm-color-primary-darkest: #7a96cb;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -10,7 +10,7 @@
 }
 
 [data-theme='dark'] {
-    --ifm-color-primary: #3c76f0;
+    --ifm-color-primary: #4a7ff2;
     --ifm-color-primary-dark: #bdcbe5;
     --ifm-color-primary-darker: #acbede;
     --ifm-color-primary-darkest: #7a96cb;


### PR DESCRIPTION
## Summary

We noticed an issue on the search when the dark mode is enabled:

<img width="811" alt="image" src="https://user-images.githubusercontent.com/46188345/195580301-24a0e4b5-a424-471f-8454-edc614586751.png">

Changing the color of the CSS var `--ifm-color-primary` to the blue of Solidus, fixes the issue and improves the readability of links and active elements.

<img width="590" alt="Screenshot 2022-10-13 at 13 08 42" src="https://user-images.githubusercontent.com/46188345/195581306-d5847b27-d115-4ccd-b5f6-0f5ff3f9658e.png">

<img width="1680" alt="Screenshot 2022-10-13 at 13 08 35" src="https://user-images.githubusercontent.com/46188345/195581334-bf3eb743-a081-4e31-962d-dc3c6e58cea5.png">

Update

The blue has been slightly changed, in order to pass all the accessibility tests.

<img width="718" alt="Screenshot 2022-10-13 at 15 30 47" src="https://user-images.githubusercontent.com/46188345/195612246-0b16c7c6-3b96-4dfb-991a-41dad2acb8a2.png">


Source: https://webaim.org/resources/contrastchecker/
## Checklist

- [X] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [X] I have verified that the preview environment works correctly.
