### PR TITLE
update events guide

### DIFF
--- a/docs/customization/subscribing-to-events.mdx
+++ b/docs/customization/subscribing-to-events.mdx
@@ -11,7 +11,7 @@ hook into Solidus events (like completing an order) and extend the associated be
 
 :::info
 
-You can run `Spree::Bus.registered_events`to get the list of available events.
+You can run `Spree::Bus.registry.event_names`to get the list of available events.
 
 :::
 
@@ -152,7 +152,7 @@ You can also assert the published payload using the `with` modifier.
 ```ruby title="spec/services/my_store/custom_service_spec.rb"
 # ...
 expect(:custom_event).to have_been_published.with(
-  a_hash_containing(order: order)
+  a_hash_including(order: order)
 )
 # ...
 ```


### PR DESCRIPTION
This PR is sponsored by [MagmaLabs](https://www.magmalabs.io/)

## Summary

- Update list events to `bus.registry.event_names` https://github.com/nebulab/omnes/blame/main/README.md#L496
- Update bus helpers use https://github.com/solidusio/solidus/blob/master/core/lib/spree/testing_support/bus_helpers.rb#L69

## Checklist

- [ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [ ] I have verified that the preview environment works correctly.
