### PR TITLE
Add missing :: operators for constants lookup

### DIFF
--- a/docs/advanced-solidus/promotions-system.mdx
+++ b/docs/advanced-solidus/promotions-system.mdx
@@ -93,7 +93,7 @@ module AmazingStore
       private
 
       def promotions
-        Spree::Promotion.
+        ::Spree::Promotion.
           active.
           joins(:promotion_rules).
           where('promotion_rules.type' => RULES_TYPE)
@@ -162,7 +162,7 @@ module AmazingStore
         }, on: :update
 
         def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
+          promotable.is_a?(::Spree::Order)
         end
 
         def eligible?(order, _options = {})


### PR DESCRIPTION
## Summary

To avoid resolving Spree as AmazingStore::Spree instead of ::Spree.

## Checklist

- [ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [ ] I have verified that the preview environment works correctly.
