### PR TITLE
Remove --skip-javascript from install guides

### DIFF
--- a/docs/getting-started/installing-solidus.mdx
+++ b/docs/getting-started/installing-solidus.mdx
@@ -58,7 +58,7 @@ If you don't have an existing Ruby on Rails application yet, simply create one w
 database:
 
 ```bash
-$ rails new amazing_store --skip-javascript
+$ rails new amazing_store
 ```
 
 Solidus doesn't require the JavaScript compiler shipped with Rails by default (Webpacker). You are

--- a/versioned_docs/version-3.2/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-3.2/getting-started/installing-solidus.mdx
@@ -58,7 +58,7 @@ If you don't have an existing Ruby on Rails application yet, simply create one w
 database:
 
 ```bash
-$ rails new amazing_store --skip-javascript
+$ rails new amazing_store
 ```
 
 Solidus doesn't require the JavaScript compiler shipped with Rails by default (Webpacker). You are

--- a/versioned_docs/version-3.3/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-3.3/getting-started/installing-solidus.mdx
@@ -58,7 +58,7 @@ If you don't have an existing Ruby on Rails application yet, simply create one w
 database:
 
 ```bash
-$ rails new amazing_store --skip-javascript
+$ rails new amazing_store
 ```
 
 Solidus doesn't require the JavaScript compiler shipped with Rails by default (Webpacker). You are


### PR DESCRIPTION
## Summary

This is no more needed assuming a Rails 7 application.

This PR is a friend of https://github.com/solidusio/solidus_starter_frontend/pull/303.

## Checklist

- [ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [ ] I have verified that the preview environment works correctly.
