### PR TITLE
Helper command to backport documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The documentation in this repo is versioned for every major and minor release.
 All changes merged to the main docs (under `docs/`) will refer to the `master` branch of the Solidus repo.
 Past versions won't generally be updated, but in case a patchlevel release requires a change it should be directed at the appropriate folder under `versioned_docs/`.
 
+We have a helper script to backport documentation changes to previous versions. Run `bin/backport -h` for more information.
+
 In order to release a new version from the documentation under `docs/` this command can be used:
 
 ```

--- a/bin/backport
+++ b/bin/backport
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+ref="HEAD"
+number_of_commits=1
+versions=""
+
+usage() {
+    echo "Helper to backport documentation changes to older versions."
+    echo ""
+    echo "It expects a reference that contains changes that only affect"
+    echo "the unreleased version. Then, it applies the generated patch"
+    echo "to the specified versions under the versioned_docs/ directory."
+    echo ""
+    echo "Notice that each version needs to be provided as a separate -v argument."
+    echo ""
+    echo "Usage: $0 [-r ref] [-n number_of_commits] -v version [-v version ...]"
+    echo "  -r ref: the ref to backport from (default: HEAD)"
+    echo "  -n number_of_commits: the number of commits to backport (default: 1)"
+    echo "  -v versions: the versions to backport to (default: none)"
+    echo "Example: $0 -v 3.3 -v 3.2"
+    echo "Example: $0 -r HEAD~ -v 3.3 -v 3.2"
+    echo "Example: $0 -r HEAD~ -n 2 -v 3.3 -v 3.2"
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+while getopts ":h:r:n:v:" options; do
+  case "${options}" in
+    h)
+      usage
+      exit 0
+      ;;
+    r)
+      ref=${OPTARG}
+      ;;
+    n)
+      number_of_commits=${OPTARG}
+      ;;
+    v)
+      versions="${versions} ${OPTARG}"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+   esac
+done
+
+for version in $versions
+do
+  git format-patch -${number_of_commits} ${ref} --stdout | git apply -p2 --directory=versioned_docs/version-$version/
+done


### PR DESCRIPTION
## Summary

Docusarus default [versioning strategy](https://docusaurus.io/docs/versioning) keeps everything on the same branch. Having to copy changes manually to older branches is a pain.

We ship a helper `bin/backport` script that will automate the process when given a git reference that only contains changes to the edge version.

```
Usage: bin/backport [-r ref] [-n number_of_commits] -v version [-v version ...]
  -r ref: the ref to backport from (default: HEAD)
  -n number_of_commits: the number of commits to backport (default: 1)
  -v versions: the versions to backport to (default: none)
```