### PR TITLE
Disable contextual search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -143,7 +143,7 @@ const config = {
         appId: 'UBY09X99OB',
         apiKey: '8ad55e50cbf0c0d82709597260065f36',
         indexName: 'edgeguides',
-        contextualSearch: true
+        contextualSearch: false,
       },
     }),
 };


### PR DESCRIPTION
## Summary

Restore algolia search across the site by disabling contextual search.

See: https://discourse.algolia.com/t/algolia-searchbar-is-not-working-with-docusaurus-v2/14659/2



## Checklist

- [x] I have verified that the preview environment works correctly.
