### PR TITLE
Use recommended user for the Docker Node image

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -8,14 +8,11 @@ RUN apt-get update -qq \
     git \
   && rm -rf /var/cache/apt/lists/*
 
-ENV APP_USER=solidusio_user \
-    LANG=C.UTF-8
-ENV APP_HOME=/home/$APP_USER/app
+ENV LANG=C.UTF-8
+ENV APP_HOME=/home/node/app
 
-RUN useradd -ms /bin/bash $APP_USER
+USER node
 
-USER $APP_USER
+RUN mkdir -p /home/node/history
 
-RUN mkdir -p /home/$APP_USER/history
-
-WORKDIR /home/$APP_USER/app
+WORKDIR /home/node/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,12 @@ services:
     image: solidus-edgeguides
     command: bash -c "(yarn check || yarn install --check-files) && tail -f /dev/null"
     environment:
-      HISTFILE: "/home/solidusio_user/history/bash_history"
+      HISTFILE: "/home/node/history/bash_history"
     ports:
       - "${SERVER_PORT:-3000}:${SERVER_PORT:-3000}"
     volumes:
-      - .:/home/solidusio_user/app:delegated
-      - history:/home/solidusio_user/history:cached
+      - .:/home/node/app:delegated
+      - history:/home/node/history:cached
     tty: true
     stdin_open: true
     tmpfs:


### PR DESCRIPTION
## Summary

The Node image for Docker [recommends](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user) using `node` as the default user.

Using another one worked with no problems in the past. For some reason, it's now not respecting the `USER` directive on the Dockerfile and using the `node` user regardless. We'll use the default recommendation to avoid troubles.

## Checklist

- ~[ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.~
- [x] I have verified that the preview environment works correctly.
