### PR TITLE
Add minimal requirements to v3.3 upgrade guides

### DIFF
--- a/docs/upgrading-solidus/v3.3.mdx
+++ b/docs/upgrading-solidus/v3.3.mdx
@@ -3,8 +3,11 @@ sidebar_position: 2
 ---
 
 import PRLink from '@site/src/theme/PRLink';
+import MinimalRequirements from '@site/src/theme/MinimalRequirements';
 
 # Solidus v3.3 (2022-01-24)
+
+<MinimalRequirements ruby="2.7" rails="6.0" />
 
 New year, new Solidus release! This time, we acknowledge our [new policy around Ruby & Rails support](https://solidus.io/release_policy/). It also comes with new features, bug fixes, as well as some deprecations that will be removed in the next major release. Take the time to upgrade. We've committed with the community to release more often, so keeping up to date will help you when Solidus v4.0 is out, which will happen sooner than later.
 

--- a/versioned_docs/version-3.3/upgrading-solidus/v3.3.mdx
+++ b/versioned_docs/version-3.3/upgrading-solidus/v3.3.mdx
@@ -3,8 +3,11 @@ sidebar_position: 1
 ---
 
 import PRLink from '@site/src/theme/PRLink';
+import MinimalRequirements from '@site/src/theme/MinimalRequirements';
 
 # Solidus v3.3 (2022-01-24)
+
+<MinimalRequirements ruby="2.7" rails="6.0" />
 
 New year, new Solidus release! This time, we acknowledge our [new policy around Ruby & Rails support](https://solidus.io/release_policy/). It also comes with new features, bug fixes, as well as some deprecations that will be removed in the next major release. Take the time to upgrade. We've committed with the community to release more often, so keeping up to date will help you when Solidus v4.0 is out, which will happen sooner than later.
 

--- a/versioned_docs/version-3.4/upgrading-solidus/v3.3.mdx
+++ b/versioned_docs/version-3.4/upgrading-solidus/v3.3.mdx
@@ -3,8 +3,11 @@ sidebar_position: 2
 ---
 
 import PRLink from '@site/src/theme/PRLink';
+import MinimalRequirements from '@site/src/theme/MinimalRequirements';
 
 # Solidus v3.3 (2022-01-24)
+
+<MinimalRequirements ruby="2.7" rails="6.0" />
 
 New year, new Solidus release! This time, we acknowledge our [new policy around Ruby & Rails support](https://solidus.io/release_policy/). It also comes with new features, bug fixes, as well as some deprecations that will be removed in the next major release. Take the time to upgrade. We've committed with the community to release more often, so keeping up to date will help you when Solidus v4.0 is out, which will happen sooner than later.
 


### PR DESCRIPTION
## Summary

We started adding that information on v3.4 (see #100).

![screenshot-localhost_3000-2023 04 24-06_43_50](https://user-images.githubusercontent.com/52650/233901878-fb3fc01e-8824-4a05-81b0-7581cd1fcb7b.png)

## Checklist

- [x] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [x] I have verified that the preview environment works correctly.
