### PR TITLE
Fix ransack attribute names

### DIFF
--- a/versioned_docs/version-3.4/upgrading-solidus/v3.3.mdx
+++ b/versioned_docs/version-3.4/upgrading-solidus/v3.3.mdx
@@ -49,7 +49,7 @@ this new tax on your store.
 
 ## <PRLink description="Deprecate discriminatory wording for Ransack methods" number="4853" />
 
-We're deprecating `.whitelist_ransackable_attributes` & `.whitelist_ransackable_associations` in favor of `.allowed_ransackable_attributes` & `.allowed_ransackable_associations`, respectively. The old terms won't be available on the next major.
+We're deprecating `.whitelisted_ransackable_attributes` & `.whitelisted_ransackable_associations` in favor of `.allowed_ransackable_attributes` & `.allowed_ransackable_associations`, respectively. The old terms won't be available on the next major.
 
 ## <PRLink description="Version upgraded for packaged underscore.js" number="4660" />
 


### PR DESCRIPTION
## Summary

Fixed a typo on `ransack` legacy attribute names.

## Checklist

- [x] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [x] I have verified that the preview environment works correctly.
