### PR TITLE
Fix markdown typo

### DIFF
--- a/docs/cookbook/redefining-checkout-steps.mdx
+++ b/docs/cookbook/redefining-checkout-steps.mdx
@@ -149,7 +149,7 @@ You can conditionally include steps in the checkout flow if necessary, by passin
 with the step in `add_checkout_step`. For example, if we only want to include our custom step if the
 orders total is over $50, we can pass that requirement in as a conditional:
 
-``ruby title="app/overrides/my_app/spree/order/add_checkout_step.rb"
+```ruby title="app/overrides/my_app/spree/order/add_checkout_step.rb"
 # frozen_string_literal: true
 
 module MyApp


### PR DESCRIPTION
## Summary

[redefining-checkout-steps.mdx](https://github.com/solidusio/edgeguides/commit/98934d92675f9e39504065faa33f9bb34f370c22) was missing a backtick `` ` ``, this pr adds it so that the code block in section **Conditional checkout steps** renders correctly.

## Checklist

- [x] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [x] I have verified that the preview environment works correctly.
