### PR TITLE
Move policies pages from solidus.io to guides

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,6 +62,21 @@ const config = {
         },
         items: [
           {
+            href: "/",
+            label: "Docs",
+            position: "left",
+          },
+          {
+            href: "/policies/security",
+            label: "Security",
+            position: "left",
+          },
+          {
+            href: "/policies/release_policy",
+            label: "Releases",
+            position: "left",
+          },
+          {
             href: "https://solidus.io",
             label: "solidus.io",
             position: "right",
@@ -117,6 +132,10 @@ const config = {
                 label: "Stack Overflow",
                 href: "https://stackoverflow.com/questions/tagged/solidus",
               },
+              {
+                label: "Community Guidelines",
+                href: "/policies/community-guidelines",
+              },
             ],
           },
           {
@@ -148,6 +167,15 @@ const config = {
     }
   ),
   plugins: [
+    [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'policies',
+        path: 'policies',
+        routeBasePath: 'policies',
+        sidebarPath: false,
+      },
+    ],
     [
       '@docusaurus/plugin-client-redirects',
       {

--- a/policies/community-guidelines.mdx
+++ b/policies/community-guidelines.mdx
@@ -1,0 +1,129 @@
+---
+sidebar_position: 3
+---
+
+# Community guidelines
+
+Like the technical community as a whole, the Solidus team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the product.
+
+Interactions in a large community such as Solidus' can sometimes lead to communication issues. To that end, we have a few ground rules that we ask people to adhere to. These guidelines apply equally to individuals in the following groups: sponsors, the Solidus stakeholders, the Solidus core team and the Solidus community.
+
+This isn't an exhaustive list of things that you should or shouldn't do. Rather, take it in the spirit in which it's intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
+
+These guidelines apply to all official Solidus spaces. This includes Slack, the Solidus GitHub organizations and any other online forums created by the core team which the community uses for communication.
+
+We don't cover spaces outside of those officially managed by the Solidus team, such as Twitter, LinkedIn, unofficial Slack communities etc. This is intentional and it strikes a balance that allows us to be inclusive of all ideas and viewpoints while also creating a safe space for our community to collaborate.
+
+If you believe someone is violating the guidelines, we ask that you report it by emailing [community@solidus.io](mailto:community@solidus.io). For more details please see our [Reporting Guidelines](#reporting-guidelines).
+
+*   **Be friendly and patient.**
+*   **Be welcoming.** We strive to be a community that welcomes and supports everyone. We intentionally refrain from making a list here, as we believe it would be superfluous: no matter your identity, you are welcome to contribute to Solidus and participate in its community.
+*   **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+*   **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. Members of the Solidus community should be respectful when dealing with other members.
+*   **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This is a comprehensive list of unacceptable behaviors:
+    *   Violent threats or language directed against another person.
+    *   Discriminatory jokes and language (i.e. insulting or belittling someone for their identity).
+    *   Posting sexually explicit or violent material.
+    *   Posting (or threatening to post) other people's personally identifying information ("doxing").
+    *   Personal insults.
+    *   Unwelcome sexual attention.
+    *   Advocating for, or encouraging, any of the above behavior.
+*   **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Solidus is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we're different. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn't mean that they're wrong, just like having someone disagreeing with you doesn't mean they don't understand your viewpoint. Don't forget that it is human to err and blaming each other doesn't get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+Original text courtesy of the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
+
+## Reporting Guidelines
+
+If you believe someone is violating the guidelines we ask that you report it to the Solidus team by emailing [community@solidus.io](mailto:community@solidus.io). **All reports will be kept confidential.** In some cases, we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+**If you believe anyone is in physical danger, please notify appropriate law enforcement first.** If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
+
+If you are unsure whether the incident is a violation, or whether the space where it happened is covered by these guidelines, we encourage you to still report it. We would much rather have a few extra reports where we decide to take no action, rather than miss a report of an actual violation. We do not look negatively on you if we find the incident is not a violation. And knowing about incidents that are not violations can help us to improve the guidelines or the processes surrounding them.
+
+In your report please include:
+
+*   Your contact info (so we can get in touch with you if we need to follow up)
+*   Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+*   When and where the incident occurred. Please be as specific as possible.
+*   Your account of what occurred. If there is a publicly available record (e.g. Slack messages) please include a link.
+*   Any extra context you believe existed for the incident.
+*   If you believe this incident is ongoing.
+*   Any other information you believe we should have.
+
+We will review and act on all reports to the best of our abilities, but we will not be able to act on reports when we are not able to collect objective information and/or witnesses that can help us clarify the incident and individuals involved.
+
+### What happens after you file a report?
+
+You will receive an email from the Solidus Community Committee acknowledging receipt immediately. We promise to acknowledge receipt within 5 business days (and will aim for much quicker than that).
+
+The committee will immediately meet to review the incident and determine:
+
+*   What happened, making sure to also ask the reported person(s).
+*   Whether this event constitutes a guidelines violation.
+*   Who the bad actor was.
+*   Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
+
+If this is determined to be an ongoing incident or a threat to physical safety, the committee's immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+
+Once the committee has a complete account of the events and all involved parties have been heard, they will make a decision as to how to respond. Responses may include:
+
+*   Nothing (if we determine no violation occurred).
+*   A private or public reprimand from the committee to the individual(s) involved.
+*   A permanent or temporary ban from some or all Solidus spaces.
+
+We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
+
+Once we've determined our final action, we'll contact the original reporter to let them know what action (if any) we'll be taking. We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
+
+### What if your report concerns a possible violation by a committee member?
+
+If your report concerns a current member of the Community Committee, you may not feel comfortable sending your report to the committee, as all members will see the report.
+
+In that case, you can make a report directly to any or all of the current chairs of the Community Committee. Their e-mail addresses are listed on the Community Committee page. The chairs will follow the usual enforcement process with the other members, but will exclude the member(s) that the report concerns from any discussion or decision making.
+
+## Enforcement Manual
+
+### The Community Committee
+
+All responses to reports of conduct violations will be managed by a Community Committee ("the committee").
+
+The Solidus stakeholders ("the stakeholders") will propose this committee, comprised of at least three members from the Solidus community. The stakeholders will review membership on a regular basis. The committee and any changes to the committee must be approved by the core team.
+
+### How the committee will respond to reports
+
+When a report is sent to the committee they will immediately reply to the report to confirm receipt. This reply must be sent within 5 days, and the committee should strive to respond much more quickly than that.
+
+See the [Reporting Guidelines](#reporting-guidelines) for details of what reports should contain. If a report doesn't contain enough information, the committee will obtain all relevant data before acting.
+
+The committee will then review the incident and determine, to the best of their ability:
+
+*   what happened;
+*   whether this event constitutes a guidelines violation;
+*   who, if anyone, was the bad actor;
+*   whether this is an ongoing situation, and there is a threat to anyone's physical safety.
+
+This information will be collected in writing, and whenever possible the committee's deliberations will be recorded and retained (i.e. Slack transcripts, email discussions, recorded voice conversations, etc).
+
+The committee should aim to have a resolution agreed upon within one week. In the event that a resolution can't be determined in that time, the committee will respond to the reporter(s) with an update and projected timeline for resolution.
+
+### Acting unilaterally
+
+If the act involves a threat to anyone's physical safety (e.g. threats of violence), any committee member may act unilaterally (before reaching consensus) to end the situation by contacting the appropriate law enforcement authorities.
+
+In situations where an individual committee member acts unilaterally, they must report their actions to the committee for review within 24 hours.
+
+### Resolutions
+
+The committee must agree on a resolution by consensus. If the committee cannot reach consensus and deadlocks for over a week, the committee will turn the matter over to the stakeholders for resolution.
+
+Possible responses may include:
+
+*   Taking no further action (if we determine no violation occurred).
+*   A private or public reprimand from the committee to the individual(s) involved.
+*   A permanent or temporary ban from some or all Solidus spaces. The committee will maintain records of all such bans so that they may be reviewed in the future, extended to new Solidus forums, or otherwise maintained.
+
+Once a resolution is agreed upon, the committee will contact the original reporter and any other affected parties and explain the resolution.
+
+### Conflicts of Interest
+
+If a report concerns a possible violation by a current committee member, this member should be excluded from the response process. For these cases, anyone can make a report directly to any of the committee chairs, as documented in the [Reporting Guidelines](#reporting-guidelines).

--- a/policies/release_policy.mdx
+++ b/policies/release_policy.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 2
+---
+
+# Release policy
+
+This document presents the Solidus team's commitment to the release cadence and policy for new Solidus releases. Users should take that as soft guidelines and not as carved in stone. We might modify it to accommodate the current state of development. On top of that, we're an Open Source project with limited resources. Nonetheless, we expect that will help Solidus users have a sense of when new features will be available and plan upgrades in advance.
+
+Solidus is in strict compliance with [Semantic Versioning](https://semver.org/). Our definition of a Breaking Change is any update to the Solidus code that can break a host application, except for:
+
+*   Issues due to the application using an interface explicitly marked as private.
+*   Issues due to the application monkey patching Solidus code.
+*   Issues due to a fix for a security or very important bug for which it hasn't been possible to implement a non-breaking solution.
+*   Issues due to the application using a Ruby, Rails or any other dependency version that is no longer maintained by the corresponding community.
+
+_The used examples for version numbers don't need to correspond to actual Solidus releases._
+
+## Patch versions: releases on backports
+
+_For example, a new patch release is transitioning from v3.2.0 to v3.2.1._
+
+Solidus releases a new patch version for a given minor whenever **something is [backported](/policies/security.mdx)**.
+
+A new patch version only contains bugs or security fixes. Most of the time, this is done backward compatible, but it could introduce a breaking change if there's no other way to fix an issue.
+
+The backport policy is not strict, but users should expect all security issues and sensible bugs to be backported to maintained versions.
+
+## Minor versions: quarterly releases
+
+_For example, a new minor release is transitioning from v3.2.1 to v3.3.0._
+
+The Solidus team will evaluate releasing a new minor **every quarter**.
+
+A new minor version can contain new features and bugs or security fixes, but it'll always add them in a backward-compatible way. Deprecation warnings are expected, but stores should keep working as before without changes to the application code as long as users run the update instructions.
+
+See the [last minor before every major section](#last_minor_before_major).
+
+## Major versions: every two years
+
+_For example, a new major release is transitioning from v3.2.0 to v4.0.0._
+
+Solidus aims to release a new major version at least **every two years**.
+
+A new major version contains breaking changes, and deprecated code is removed.
+
+See the [last minor before every major section](#last_minor_before_major).
+
+## Last minor before every major {#last_minor_before_major}
+
+_For example, the last minor before a major is v3.2.10 if the next release is v4.0.0._
+
+The final minor version in a major series (e.g., v3.2.10) and the first one in the next (e.g., v4.0.0) are identical, besides removing deprecated code.
+
+All the deprecation warnings on the last minor version are removed in the next major, and the application code is expected to comply. That means an application that has been updated to the latest minor and adapted to avoid any deprecation warning should keep working on the first minor release of the next series.
+
+There could be exceptions when there's no way to introduce a new feature without deprecating old behavior first, but that should be well documented in the [Changelog](#changelog).
+
+Master is frozen after the final minor version in a series and until the next major is released. Both releases should happen very close in time.
+
+## Changelog
+
+The [Changelog in Solidus' main branch](https://github.com/solidusio/solidus/blob/main/CHANGELOG.md) is the unique source of truth for the changes made to the project.
+
+It shouldn't be expected for the Changelog files in other branches in the repository or packaged gems to be complete.

--- a/policies/security.mdx
+++ b/policies/security.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_position: 1
+---
+
+import SupportedVersions from '@site/src/theme/SupportedVersions';
+
+# Security
+
+We take security very seriously and adopt industry best practices to minimize the likelihood of introducing vulnerabilities in the Solidus codebase. For us, security also means having a clear policy in place for reporting and patching vulnerabilities.
+
+## Supported Versions
+
+Solidus versions will receive security patches for 18 months after their initial [release](/policies/release_policy.mdx).
+
+The following table represents the latest versions with their release date, EOL date and current support state.
+
+<SupportedVersions />
+
+## Reporting a vulnerability
+
+**We promise to be always responsive and thankful to those who report any security vulnerabilities following the instructions described here.**
+
+All security bugs in Solidus should be reported through our [vulnerability disclosure program page at HackerOne](https://hackerone.com/solidus). This will deliver a message to a subset of the Core Team who handle security issues. Your report will be acknowledged as soon as possible and we'll try to get in touch within 5 days.
+
+We may ask you to access the Security Advisory created in GitHub to help us discover more about the report, fix it, and also to keep you informed on progress.
+
+Alternatively, you’ll just receive a detailed response indicating the next steps in handling your report. After the first reply to your report, the security team will keep you informed of the progress being made towards a fix and full announcement. These updates will be sent at least every 5 days.
+
+If you have not received a reply to your report within 5 days, or have not heard from the security team for the past 5 days, please, either:
+
+*   Contact the current security coordinators [security@solidus.io](mailto:security@solidus.io) .
+*   Contact any other Solidus Core Team member on [Slack](http://slack.solidus.io/) via direct message.
+
+All response target times are tracked and reported in business days. Business days are defined to be:
+
+*   Monday - Friday
+*   24 hours
+*   Including holidays (hackers never sleep!)
+
+## Disclosure process
+
+#### 1\. Security Report Received
+
+*   Report is assigned a primary handler. This person will coordinate the fix and release process.
+*   Problem is confirmed and a list of all affected versions is determined.
+*   Code is audited to find any potential similar problems.
+
+#### 2\. Vulnerability Fixed
+
+*   A new [Security Advisory](https://help.github.com/en/articles/about-maintainer-security-advisories) is created in GitHub to privately discuss and fix the vulnerability reported. This will also allow publishing a security alert to Solidus users directly on GitHub, only visible to repository users with admin permissions.
+*   Fixes are prepared for all releases which are still supported. These fixes are not committed to the public repository but rather held privately pending the announcement.
+
+#### 3\. Vulnerability Published
+
+_These actions should be done within the same business day._
+
+*   The GitHub Security Advisory is published.
+*   A [Solidus Security mailing list](https://groups.google.com/forum/#!forum/solidus-security) thread is created.
+*   Fixed gems versions are released to RubyGems.
+*   A blog post is published on solidus.io.
+
+## Receiving disclosures
+
+The best way to receive all the security announcements is to [enable alerts for vulnerable dependencies in GitHub](https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies) or to subscribe to the [Solidus Security mailing list](https://groups.google.com/forum/#!forum/solidus-security). The mailing list is very low traffic, and it receives the public notifications the moment the vulnerability is published.
+
+If you have any suggestions to improve this policy, please send an email to the [security policy team](mailto:security@solidus.io).
+
+## Additional Security Initiatives
+
+In addition to the Disclosure Program above we also enforce the security of the codebase and released gems through the following initiatives:
+
+*   **Two mandatory PR reviews from the Core Team:** Before merging any PR we need two mandatory reviews from members of the Core Team, which helps spot security issues.
+*   **Multi-factor authentication enabled on RubyGems:** All users who have permissions to release a core gem of Solidus need to have [multi-factor authentication enabled on RubyGems](https://guides.rubygems.org/setting-up-multifactor-authentication/) to avoid gem hijacking.
+*   **Automated GitHub Security Fixes:** When one of the Solidus dependencies receives a security fix, GitHub automatically submits a Pull Request on our repository to require the library at the patched version.

--- a/src/theme/SupportedVersions.js
+++ b/src/theme/SupportedVersions.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+export default function SupportedVersions() {
+  const versions = [
+    { number: 'v4.1', releaseDate: '2023-06-29', eolDate: '2024-12-29' },
+    { number: 'v4.0', releaseDate: '2023-05-08', eolDate: '2024-11-08' },
+    { number: 'v3.4', releaseDate: '2023-04-21', eolDate: '2024-10-21' },
+    { number: 'v3.3', releaseDate: '2023-01-24', eolDate: '2024-07-24' },
+    { number: 'v3.2', releaseDate: '2022-08-18', eolDate: '2024-02-18' },
+    { number: 'v3.1', releaseDate: '2021-09-10', eolDate: '2023-03-10' },
+    { number: 'v3.0', releaseDate: '2021-04-20', eolDate: '2022-10-20' },
+    { number: 'v2.11', releaseDate: '2020-10-23', eolDate: '2022-04-23' },
+    { number: 'v2.10', releaseDate: '2020-01-15', eolDate: '2021-07-15' },
+    { number: 'v2.9', releaseDate: '2019-07-16', eolDate: '2021-01-16' },
+    { number: 'v2.8', releaseDate: '2019-01-29', eolDate: '2020-07-29' },
+    { number: 'v2.7', releaseDate: '2018-09-14', eolDate: '2020-03-14' },
+    { number: 'v2.6', releaseDate: '2018-06-16', eolDate: '2019-12-16' },
+    { number: 'v2.5', releaseDate: '2018-03-27', eolDate: '2019-09-27' },
+    { number: 'v2.4', releaseDate: '2017-11-07', eolDate: '2019-05-07' }
+  ];
+
+  return (
+    <div className="supported_versions">
+      <table>
+        <thead>
+          <tr>
+            <th>Version Number</th>
+            <th>Release Date</th>
+            <th>End of Life Date</th>
+            <th>Supported</th>
+          </tr>
+        </thead>
+        <tbody>
+          {versions.map(version => (
+            <tr
+              key={version.number}
+            >
+              <td>{version.number}</td>
+              <td>{version.releaseDate}</td>
+              <td>{version.eolDate}</td>
+              <td>{isSupported(version.eolDate) ? '✅' : '⛔️'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Function to check if a version is still supported based on the end of life date
+function isSupported(eolDate) {
+  const endOfLifeDateTime = new Date(eolDate).getTime();
+  return Date.now() < endOfLifeDateTime;
+}


### PR DESCRIPTION
## Summary

It is almost a 1-1 copy from the solidus website repository, but I had to rewrite in JS the code that creates the supported versions table and check dynamically if a version is still supported or not (thanks for the help ChatGPT 🤖).

~When approved, I'll generate the corresponding pages for the 4.1 version for immediate availability.~ see https://github.com/solidusio/edgeguides/pull/120#issuecomment-1625543089

## Checklist

- [ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [ ] I have verified that the preview environment works correctly.
