### PR TITLE
Make the PRLink use the tag contents as the title

### DIFF
--- a/docs/upgrading-solidus/v3.3.mdx
+++ b/docs/upgrading-solidus/v3.3.mdx
@@ -13,11 +13,11 @@ New year, new Solidus release! This time, we acknowledge our [new policy around 
 
 Before getting hands-on, please review our generic [upgrade guides](/upgrading-solidus/index.mdx). You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.3/CHANGELOG.md) in our repository.
 
-## <PRLink description="Added support for Ruby v3.2" number="4817" />
+## <PRLink number="4817">Added support for Ruby v3.2</PRLink>
 
 Solidus v3.3 comes with support for the recently released v3.2 of Ruby. You can safely upgrade to it without Solidus getting in your way.
 
-## <PRLink description="Removed support for Ruby v2.5" number="4845" />
+## <PRLink number="4845">Removed support for Ruby v2.5</PRLink>
 
 With v3.3, Solidus performs a long-due cleanup of its codebase, removing support for EOL's Ruby versions v2.5 & v2.6. If you're on Solidus v3.2 and you want to upgrade to v3.3:
 
@@ -25,21 +25,21 @@ With v3.3, Solidus performs a long-due cleanup of its codebase, removing support
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Ruby v2.6" number="4848" />
+## <PRLink number="4848">Removed support for Ruby v2.6</PRLink>
 
 Solidus v3.3 no longer supports Ruby v2.6, which reached the EOL status. You'll need to:
 
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Rails v5.2" number="4850" />
+## <PRLink number="4850">Removed support for Rails v5.2</PRLink>
 
 Rails v5.2 (EOL) support has been removed from Solidus v3.3:
 
 - Update your Solidus v3.2 store to Rails v6.0.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Support for the new Colorado delivery fee" number="4491" />
+## <PRLink number="4491">Support for the new Colorado delivery fee</PRLink>
 
 We've updated our taxation system to support the new [Colorado retail delivery fee](https://tax.colorado.gov/retail-delivery-fee).
 Please, check [the corresponding guide page][how-to-setup-colorado-delivery-fee] to setup
@@ -47,19 +47,19 @@ this new tax on your store.
 
 [how-to-setup-colorado-delivery-fee]: ../how-tos/how-to-setup-colorado-delivery-fee
 
-## <PRLink description="Deprecate discriminatory wording for Ransack methods" number="4853" />
+## <PRLink number="4853">Deprecate discriminatory wording for Ransack methods</PRLink>
 
 We're deprecating `.whitelisted_ransackable_attributes` & `.whitelisted_ransackable_associations` in favor of `.allowed_ransackable_attributes` & `.allowed_ransackable_associations`, respectively. The old terms won't be available on the next major.
 
-## <PRLink description="Version upgraded for packaged underscore.js" number="4660" />
+## <PRLink number="4660">Version upgraded for packaged underscore.js</PRLink>
 
 We've upgraded the packaged version of [underscore.js](https://underscorejs.org/) from v1.8.3 to v1.13.6. In case you were using it, check compatibility.
 
-## <PRLink description="Deprecated #mails_from preference" number="4712" />
+## <PRLink number="4712">Deprecated #mails_from preference</PRLink>
 
 We've deprecated the `#mails_from` preference, as it wasn't used in the Solidus codebase anymore. Make sure you aren't using it for anything else. Otherwise, the expected way to handle the default `From:` field for transactional emails is the `Spree::Store#mail_from_address` attribute.
 
-## <PRLink description="Store static preferences using string class names" number="4858" />
+## <PRLink number="4858">Store static preferences using string class names</PRLink>
 
 It's no longer necessary to wrap the definition of static preferences within a `.to_prepare` block to avoid [referencing a constant on an initializer](https://guides.rubyonrails.org/v6.1.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots).
 
@@ -86,7 +86,7 @@ Spree::Config.static_model_preferences.add(
 )
 ```
 
-## <PRLink description="Configurable promotion adjuster" number="4460" />
+## <PRLink number="4460">Configurable promotion adjuster</PRLink>
 
 You can now change what the default promotion adjuster does. Configure the `Spree::Config.promotion_adjuster_class`
 preference with a class that takes the order on initialization and responds to the `#call` method.
@@ -95,7 +95,7 @@ Read [the corresponding how-to][how-to-use-a-custom-promotion-adjuster] for more
 
 [how-to-use-a-custom-promotion-adjuster]: ../how-tos/how-to-use-a-custom-promotion-adjuster
 
-## <PRLink description="Configurable algorithm to prioritize store credits" number="4677" />
+## <PRLink number="4677">Configurable algorithm to prioritize store credits</PRLink>
 
 Before v3.3, store credits were always sorted by the priority of their type. Now you can change
 that behavior by configuring the `Spree::Config.store_credit_prioritizer_class` preference with
@@ -124,19 +124,19 @@ module MyStore
 end
 ```
 
-## <PRLink description="Allow shipping category on variants" number="4739" />
+## <PRLink number="4739">Allow shipping category on variants</PRLink>
 
 It was already possible for a variant to have a different tax category than its product. Now, that's also true for the shipping category.
 
-## <PRLink description="Default implementation for PaymentMethod#try_void" number="4843" />
+## <PRLink number="4843">Default implementation for PaymentMethod#try_void</PRLink>
 
 When adding a new payment integration, it was required to implement the `PaymentMethod#try_void` method. However, it turned out that the logic was always very similar. We now provide a default implementation that would be enough in most situations.
 
-## <PRLink description="Improved bogus credit card voiding" number="4861" />
+## <PRLink number="4861">Improved bogus credit card voiding</PRLink>
 
 Before this change, all attempts to void a payment with this testing payment method in the admin panel were successful. It's now possible to simulate a failure by trying to cancel an order with a captured payment.
 
-## <PRLink description="Variant and product autocomplete functions flexibility with Ransack" number="4767" />
+## <PRLink number="4767">Variant and product autocomplete functions flexibility with Ransack</PRLink>
 
 It's now possible to customize the autocompletion for variants and products on the backend via a callback returning a Ransack query. E.x.:
 
@@ -152,6 +152,6 @@ $('#product-dropdown').productAutocomplete({
 })
 ```
 
-## <PRLink description="Add available in product's Ransack scopes" number="4852" />
+## <PRLink number="4852">Add available in product's Ransack scopes</PRLink>
 
 `.available` is now available to be used as a [Ransack scope](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#using-scopesclass-methods) in `Spree::Product`

--- a/docs/upgrading-solidus/v3.4.mdx
+++ b/docs/upgrading-solidus/v3.4.mdx
@@ -13,7 +13,7 @@ This is a slimmer release, but a very important one as it'll be the last on the 
 
 Please, remember to review our generic [upgrade guides](/upgrading-solidus/index.mdx) and run the `bin/rails g solidus:update` task. You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.4/CHANGELOG.md) in our repository.
 
-## <PRLink description="New taxon and taxonomy validations" number="4851" />
+## <PRLink number="4851">New taxon and taxonomy validations</PRLink>
 
 New validations were added to the `Taxon` and `Taxonomy` models but are behind the new temporary `extra_taxon_validations` and `extra_taxonomy_validations` preferences.
 
@@ -36,7 +36,7 @@ On top of that, some of your tests may break if you have incorrectly built Taxon
 - As before, if you pass no `taxonomy`, a Taxonomy and its root Taxon will be made.
 - Now, the `parent` will be inferred from the given `taxonomy` or default created Taxonomy. This means, the created Taxon will always be nested (if you want a root Taxon, create a Taxonomy and get its root).
 
-## <PRLink description="Configurable order update attributes class" number="4955" />
+## <PRLink number="4955">Configurable order update attributes class</PRLink>
 
 `Spree::OrderUpdateAttributes` class is no longer hard-coded. That will grant you flexibility if you need to store additional attributes during checkout.
 
@@ -65,7 +65,7 @@ module MyStore
 end
 ```
 
-## <PRLink description="Configure allowed ransackable scopes" number="4956" />
+## <PRLink number="4956">Configure allowed ransackable scopes</PRLink>
 
 We already had allowed ransackable attributes and associations to configure [authorization on Ransack](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#authorization-allowlistingdenylisting). We added the missing `allowed_ransackable_scopes` piece, allowing you to modify the defaults without overriding the `.ransack_scopes` method:
 
@@ -73,19 +73,19 @@ We already had allowed ransackable attributes and associations to configure [aut
 Spree::Product.allowed_ransackable_scopes.concat([:new_scope])
 ```
 
-## <PRLink description="Improvements for the risk analysis report" number="4883" />
+## <PRLink number="4883">Improvements for the risk analysis report</PRLink>
 
 The payment risk analysis summary rendered for orders considered dangerous now contains information for all the associated payments instead of only considering the last one.
 
-## <PRLink description="Easily change from frontend to admin view for an order" number="4886" />
+## <PRLink number="4886">Easily change from frontend to admin view for an order</PRLink>
 
 That's a small quality of life improvement. If you're checking out an order in the storefront, you can now prepend `/admin` to the route and land in the admin panel counterpart. Very helpful during development and testing.
 
-## <PRLink description="All-encompassing update task" number="4957" />
+## <PRLink number="4957">All-encompassing update task</PRLink>
 
 Before, running `bin/rails solidus:update` would only generate the initializer to [update default Solidus preferences](/upgrading-solidus/index.mdx#updating-preferences]). Now, it'll also copy the new migration files to your host application. Remember, you'll still need to check and run them by yourself.
 
-## <PRLink description="Deprecate promotions with an `any` policy" number="4991" />
+## <PRLink number="4991">Deprecate promotions with an `any` policy</PRLink>
 
 Actually, promotions with a `match_policy` of `any` were deprecated on v3.2. We forgot to add a deprecation warning, so you may only realize it now.
 
@@ -97,10 +97,10 @@ bin/rake solidus:split_promotions_with_any_match_policy
 
 That will create separate promotions for each of the rules of your promotions with `any` match policy, which should have the same outcome for customers.
 
-## <PRLink description="Deprecation of payment offsets" number="5008" />
+## <PRLink number="5008">Deprecation of payment offsets</PRLink>
 
 That's just some dangling code removal, as payment offsets (the old refund system) have not been used on Solidus for a long time. You must move entirely to the well-established refund system if you're still using them.
 
-## <PRLink description="Deprecated `#line_item_shipment_price`" number="4876" />
+## <PRLink number="4876">Deprecated `#line_item_shipment_price`</PRLink>
 
 The `Admin::OrdersHelper#line_item_shipment_price` method has been deprecated. You can use the equivalent `Spree::LineItem#display_amount` instead.

--- a/docs/upgrading-solidus/v4.0.mdx
+++ b/docs/upgrading-solidus/v4.0.mdx
@@ -36,7 +36,7 @@ Here's a list of things you should take care of.
 
 ## Changes/Removals without deprecation
 
-## <PRLink description="Removed support for Rails < 7 & Ruby < 3" number="5012" />
+## <PRLink number="5012">Removed support for Rails < 7 & Ruby < 3</PRLink>
 
 To have Solidus ready for what comes next, we need everyone to use at least Rails 7. That's because we have a plan to
 switch the Admin Panel to the Hotwire stack, which is now the default in the Rails world.
@@ -50,7 +50,7 @@ Rails iteratively before the Solidus major upgrade.
 
 Along with that, we also removed support for older Ruby versions: **you need at least Ruby 3.0 to use Solidus v4.0**.
 
-## <PRLink description="Make option value to variant association unique" number="4146" />
+## <PRLink number="4146">Make option value to variant association unique</PRLink>
 
 The same option value cannot be associated anymore with a given variant multiple times. It's very likely
 that you are not doing this, but this change introduces a new unique index on the `spree_option_values_variants` database table, which is going to fail if you have duplicate records.
@@ -64,26 +64,26 @@ Spree::OptionValuesVariant.select(:variant_id,:option_value_id).group(:variant_i
 
 If the script above returns anything different from `{}`, you need to remove those duplicates.
 
-## <PRLink description="Remove deprecated_address_id column from shipments" number="4379" />
+## <PRLink number="4379">Remove deprecated_address_id column from shipments</PRLink>
 
 We have not used this column since we removed all references to it in 2016. Be sure you are also
 never using it.
 
-## <PRLink description="Remove position column from spree_taxons" number="4754" />
+## <PRLink number="4754">Remove position column from spree_taxons</PRLink>
 
 Apparently, taxons used to be a list in very early versions of Spree, and have then been refactored to be a nested set. Nested sets are strict supersets of lists,
 so the `position` column is entirely unnecessary.
 
 Please, be sure you are never using it, and if you do, just re-add it with a new migration.
 
-## <PRLink description="Remove unused columns from spree_promotion_rules" number="4881" />
+## <PRLink number="4881">Remove unused columns from spree_promotion_rules</PRLink>
 
 We are cleaning up the `spree_promotion_rules` table from useless columns:
 
 - `product_group_id` refers to something that was removed from Spree in version 1.1 (see https://github.com/spree-contrib/spree_product_groups).
 - `code` refers to nothing.
 
-## <PRLink description="Drop unused table promotion_action_line_items" number="4882" />
+## <PRLink number="4882">Drop unused table promotion_action_line_items</PRLink>
 
 There's another table with identical columns that is being referenced in the codebase, `spree_line_item_actions`.
 

--- a/docs/upgrading-solidus/v4.1.mdx
+++ b/docs/upgrading-solidus/v4.1.mdx
@@ -31,7 +31,7 @@ You can also check the complete [Changelog](https://github.com/solidusio/solidus
 
 :::
 
-## <PRLink description="Add a new admin theme" number="5092" />
+## <PRLink number="5092">Add a new admin theme</PRLink>
 
 https://github.com/solidusio/solidus/pull/5092 is the first step towards the new Admin. It introduces a new
 theme, which is a set of colors and styles that can be applied to the Admin.
@@ -42,7 +42,7 @@ To switch to the new theme, you can set the following preference:
 Spree::Backend::Config.theme = 'solidus_admin'
 ```
 
-## <PRLink description="Allow changing the order recalculator" number="5110" />
+## <PRLink number="5110">Allow changing the order recalculator</PRLink>
 
 The `order.recalculate` and `order.recalculator` are introduced as aliases to the now deprecated
 `order.update` and `order.updater` in order to clarify the intention of these methods.
@@ -55,7 +55,7 @@ your own class that inherits from the current OrderUpdater class and set the new
 Spree::Config.order_recalculator_class = 'YourCustomOrderRecalucator'
 ```
 
-## <PRLink description="Remove respond_to :html from Spree::BaseController" number="5158" />
+## <PRLink number="5158">Remove respond_to :html from Spree::BaseController</PRLink>
 
 When we removed the gem `responders` as a core dependency (it still is for backend and api),
 we forgot to move the `respond_to :html` statement from `Spree::BaseController`, which is part
@@ -71,7 +71,7 @@ could be broken if these statements are true together:
 
 If that's the case, you can just add `respond_to :html` in that controller to fix it.
 
-## <PRLink description="Allow lambda in menu item :match_path option and URL" number="5152" />
+## <PRLink number="5152">Allow lambda in menu item :match_path option and URL</PRLink>
 
 This change allows setting a path for a menu item via a lambda executed at runtime. If engines other than Solidus
 would like their route in the main menu, this is how they can do it dynamically without having to hard-code the path.

--- a/src/theme/PRLink.js
+++ b/src/theme/PRLink.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PRIcon from '@site/static/img/pr.png';
 
-export default function PRLink(props) {
+export default function PRLink({number, children}) {
   return (
-    <a class="pull_request" href={ `https://github.com/solidusio/solidus/pull/${ props.number }` }>
-      { props.description }
+    <a class="pull_request" href={ `https://github.com/solidusio/solidus/pull/${ number }` }>
+      { children }
     </a>
   );
 };

--- a/versioned_docs/version-3.3/upgrading-solidus/v3.3.mdx
+++ b/versioned_docs/version-3.3/upgrading-solidus/v3.3.mdx
@@ -13,11 +13,11 @@ New year, new Solidus release! This time, we acknowledge our [new policy around 
 
 Before getting hands-on, please review our generic [upgrade guides](/getting-started/upgrading-solidus.mdx). You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.3/CHANGELOG.md) in our repository.
 
-## <PRLink description="Added support for Ruby v3.2" number="4817" />
+## <PRLink number="4817">Added support for Ruby v3.2</PRLink>
 
 Solidus v3.3 comes with support for the recently released v3.2 of Ruby. You can safely upgrade to it without Solidus getting in your way.
 
-## <PRLink description="Removed support for Ruby v2.5" number="4845" />
+## <PRLink number="4845">Removed support for Ruby v2.5</PRLink>
 
 With v3.3, Solidus performs a long-due cleanup of its codebase, removing support for EOL's Ruby versions v2.5 & v2.6. If you're on Solidus v3.2 and you want to upgrade to v3.3:
 
@@ -25,21 +25,21 @@ With v3.3, Solidus performs a long-due cleanup of its codebase, removing support
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Ruby v2.6" number="4848" />
+## <PRLink number="4848">Removed support for Ruby v2.6</PRLink>
 
 Solidus v3.3 no longer supports Ruby v2.6, which reached the EOL status. You'll need to:
 
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Rails v5.2" number="4850" />
+## <PRLink number="4850">Removed support for Rails v5.2</PRLink>
 
 Rails v5.2 (EOL) support has been removed from Solidus v3.3:
 
 - Update your Solidus v3.2 store to Rails v6.0.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Support for the new Colorado delivery fee" number="4491" />
+## <PRLink number="4491">Support for the new Colorado delivery fee</PRLink>
 
 We've updated our taxation system to support the new [Colorado retail delivery fee](https://tax.colorado.gov/retail-delivery-fee).
 Please, check [the corresponding guide page][how-to-setup-colorado-delivery-fee] to setup
@@ -47,19 +47,19 @@ this new tax on your store.
 
 [how-to-setup-colorado-delivery-fee]: ../how-tos/how-to-setup-colorado-delivery-fee
 
-## <PRLink description="Deprecate discriminatory wording for Ransack methods" number="4853" />
+## <PRLink number="4853">Deprecate discriminatory wording for Ransack methods</PRLink>
 
 We're deprecating `.whitelisted_ransackable_attributes` & `.whitelisted_ransackable_associations` in favor of `.allowed_ransackable_attributes` & `.allowed_ransackable_associations`, respectively. The old terms won't be available on the next major.
 
-## <PRLink description="Version upgraded for packaged underscore.js" number="4660" />
+## <PRLink number="4660">Version upgraded for packaged underscore.js</PRLink>
 
 We've upgraded the packaged version of [underscore.js](https://underscorejs.org/) from v1.8.3 to v1.13.6. In case you were using it, check compatibility.
 
-## <PRLink description="Deprecated #mails_from preference" number="4712" />
+## <PRLink number="4712">Deprecated #mails_from preference</PRLink>
 
 We've deprecated the `#mails_from` preference, as it wasn't used in the Solidus codebase anymore. Make sure you aren't using it for anything else. Otherwise, the expected way to handle the default `From:` field for transactional emails is the `Spree::Store#mail_from_address` attribute.
 
-## <PRLink description="Store static preferences using string class names" number="4858" />
+## <PRLink number="4858">Store static preferences using string class names</PRLink>
 
 It's no longer necessary to wrap the definition of static preferences within a `.to_prepare` block to avoid [referencing a constant on an initializer](https://guides.rubyonrails.org/v6.1.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots).
 
@@ -86,7 +86,7 @@ Spree::Config.static_model_preferences.add(
 )
 ```
 
-## <PRLink description="Configurable promotion adjuster" number="4460" />
+## <PRLink number="4460">Configurable promotion adjuster</PRLink>
 
 You can now change what the default promotion adjuster does. Configure the `Spree::Config.promotion_adjuster_class`
 preference with a class that takes the order on initialization and responds to the `#call` method.
@@ -95,7 +95,7 @@ Read [the corresponding how-to][how-to-use-a-custom-promotion-adjuster] for more
 
 [how-to-use-a-custom-promotion-adjuster]: ../how-tos/how-to-use-a-custom-promotion-adjuster
 
-## <PRLink description="Configurable algorithm to prioritize store credits" number="4677" />
+## <PRLink number="4677">Configurable algorithm to prioritize store credits</PRLink>
 
 Before v3.3, store credits were always sorted by the priority of their type. Now you can change that behavior by configuring the `Spree::Config.store_credit_prioritizer_class` preference with a class that takes the store credits and the order on initialization and responds to the `#call` method.
 
@@ -121,19 +121,19 @@ module MyStore
 end
 ```
 
-## <PRLink description="Allow shipping category on variants" number="4739" />
+## <PRLink number="4739">Allow shipping category on variants</PRLink>
 
 It was already possible for a variant to have a different tax category than its product. Now, that's also true for the shipping category.
 
-## <PRLink description="Default implementation for PaymentMethod#try_void" number="4843" />
+## <PRLink number="4843">Default implementation for PaymentMethod#try_void</PRLink>
 
 When adding a new payment integration, it was required to implement the `PaymentMethod#try_void` method. However, it turned out that the logic was always very similar. We now provide a default implementation that would be enough in most situations.
 
-## <PRLink description="Improved bogus credit card voiding" number="4861" />
+## <PRLink number="4861">Improved bogus credit card voiding</PRLink>
 
 Before this change, all attempts to void a payment with this testing payment method in the admin panel were successful. It's now possible to simulate a failure by trying to cancel an order with a captured payment.
 
-## <PRLink description="Variant and product autocomplete functions flexibility with Ransack" number="4767" />
+## <PRLink number="4767">Variant and product autocomplete functions flexibility with Ransack</PRLink>
 
 It's now possible to customize the autocompletion for variants and products on the backend via a callback returning a Ransack query. E.x.:
 
@@ -149,6 +149,6 @@ $('#product-dropdown').productAutocomplete({
 })
 ```
 
-## <PRLink description="Add available in product's Ransack scopes" number="4852" />
+## <PRLink number="4852">Add available in product's Ransack scopes</PRLink>
 
 `.available` is now available to be used as a [Ransack scope](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#using-scopesclass-methods) in `Spree::Product`

--- a/versioned_docs/version-3.4/upgrading-solidus/v3.3.mdx
+++ b/versioned_docs/version-3.4/upgrading-solidus/v3.3.mdx
@@ -13,11 +13,11 @@ New year, new Solidus release! This time, we acknowledge our [new policy around 
 
 Before getting hands-on, please review our generic [upgrade guides](/getting-started/upgrading-solidus.mdx). You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.3/CHANGELOG.md) in our repository.
 
-## <PRLink description="Added support for Ruby v3.2" number="4817" />
+## <PRLink number="4817">Added support for Ruby v3.2</PRLink>
 
 Solidus v3.3 comes with support for the recently released v3.2 of Ruby. You can safely upgrade to it without Solidus getting in your way.
 
-## <PRLink description="Removed support for Ruby v2.5" number="4845" />
+## <PRLink number="4845">Removed support for Ruby v2.5</PRLink>
 
 With v3.3, Solidus performs a long-due cleanup of its codebase, removing support for EOL's Ruby versions v2.5 & v2.6. If you're on Solidus v3.2 and you want to upgrade to v3.3:
 
@@ -25,21 +25,21 @@ With v3.3, Solidus performs a long-due cleanup of its codebase, removing support
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Ruby v2.6" number="4848" />
+## <PRLink number="4848">Removed support for Ruby v2.6</PRLink>
 
 Solidus v3.3 no longer supports Ruby v2.6, which reached the EOL status. You'll need to:
 
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Rails v5.2" number="4850" />
+## <PRLink number="4850">Removed support for Rails v5.2</PRLink>
 
 Rails v5.2 (EOL) support has been removed from Solidus v3.3:
 
 - Update your Solidus v3.2 store to Rails v6.0.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Support for the new Colorado delivery fee" number="4491" />
+## <PRLink number="4491">Support for the new Colorado delivery fee</PRLink>
 
 We've updated our taxation system to support the new [Colorado retail delivery fee](https://tax.colorado.gov/retail-delivery-fee).
 Please, check [the corresponding guide page][how-to-setup-colorado-delivery-fee] to setup
@@ -47,19 +47,19 @@ this new tax on your store.
 
 [how-to-setup-colorado-delivery-fee]: ../how-tos/how-to-setup-colorado-delivery-fee
 
-## <PRLink description="Deprecate discriminatory wording for Ransack methods" number="4853" />
+## <PRLink number="4853">Deprecate discriminatory wording for Ransack methods</PRLink>
 
 We're deprecating `.whitelisted_ransackable_attributes` & `.whitelisted_ransackable_associations` in favor of `.allowed_ransackable_attributes` & `.allowed_ransackable_associations`, respectively. The old terms won't be available on the next major.
 
-## <PRLink description="Version upgraded for packaged underscore.js" number="4660" />
+## <PRLink number="4660">Version upgraded for packaged underscore.js</PRLink>
 
 We've upgraded the packaged version of [underscore.js](https://underscorejs.org/) from v1.8.3 to v1.13.6. In case you were using it, check compatibility.
 
-## <PRLink description="Deprecated #mails_from preference" number="4712" />
+## <PRLink number="4712">Deprecated #mails_from preference</PRLink>
 
 We've deprecated the `#mails_from` preference, as it wasn't used in the Solidus codebase anymore. Make sure you aren't using it for anything else. Otherwise, the expected way to handle the default `From:` field for transactional emails is the `Spree::Store#mail_from_address` attribute.
 
-## <PRLink description="Store static preferences using string class names" number="4858" />
+## <PRLink number="4858">Store static preferences using string class names</PRLink>
 
 It's no longer necessary to wrap the definition of static preferences within a `.to_prepare` block to avoid [referencing a constant on an initializer](https://guides.rubyonrails.org/v6.1.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots).
 
@@ -86,7 +86,7 @@ Spree::Config.static_model_preferences.add(
 )
 ```
 
-## <PRLink description="Configurable promotion adjuster" number="4460" />
+## <PRLink number="4460">Configurable promotion adjuster</PRLink>
 
 You can now change what the default promotion adjuster does. Configure the `Spree::Config.promotion_adjuster_class`
 preference with a class that takes the order on initialization and responds to the `#call` method.
@@ -95,7 +95,7 @@ Read [the corresponding how-to][how-to-use-a-custom-promotion-adjuster] for more
 
 [how-to-use-a-custom-promotion-adjuster]: ../how-tos/how-to-use-a-custom-promotion-adjuster
 
-## <PRLink description="Configurable algorithm to prioritize store credits" number="4677" />
+## <PRLink number="4677">Configurable algorithm to prioritize store credits</PRLink>
 
 Before v3.3, store credits were always sorted by the priority of their type. Now you can change
 that behavior by configuring the `Spree::Config.store_credit_prioritizer_class` preference with
@@ -124,19 +124,19 @@ module MyStore
 end
 ```
 
-## <PRLink description="Allow shipping category on variants" number="4739" />
+## <PRLink number="4739">Allow shipping category on variants</PRLink>
 
 It was already possible for a variant to have a different tax category than its product. Now, that's also true for the shipping category.
 
-## <PRLink description="Default implementation for PaymentMethod#try_void" number="4843" />
+## <PRLink number="4843">Default implementation for PaymentMethod#try_void</PRLink>
 
 When adding a new payment integration, it was required to implement the `PaymentMethod#try_void` method. However, it turned out that the logic was always very similar. We now provide a default implementation that would be enough in most situations.
 
-## <PRLink description="Improved bogus credit card voiding" number="4861" />
+## <PRLink number="4861">Improved bogus credit card voiding</PRLink>
 
 Before this change, all attempts to void a payment with this testing payment method in the admin panel were successful. It's now possible to simulate a failure by trying to cancel an order with a captured payment.
 
-## <PRLink description="Variant and product autocomplete functions flexibility with Ransack" number="4767" />
+## <PRLink number="4767">Variant and product autocomplete functions flexibility with Ransack</PRLink>
 
 It's now possible to customize the autocompletion for variants and products on the backend via a callback returning a Ransack query. E.x.:
 
@@ -152,6 +152,6 @@ $('#product-dropdown').productAutocomplete({
 })
 ```
 
-## <PRLink description="Add available in product's Ransack scopes" number="4852" />
+## <PRLink number="4852">Add available in product's Ransack scopes</PRLink>
 
 `.available` is now available to be used as a [Ransack scope](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#using-scopesclass-methods) in `Spree::Product`

--- a/versioned_docs/version-3.4/upgrading-solidus/v3.4.mdx
+++ b/versioned_docs/version-3.4/upgrading-solidus/v3.4.mdx
@@ -13,7 +13,7 @@ This is a slimmer release, but a very important one as it'll be the last on the 
 
 Please, remember to review our generic [upgrade guides](/getting-started/upgrading-solidus.mdx) and run the `bin/rails g solidus:update` task. You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.4/CHANGELOG.md) in our repository.
 
-## <PRLink description="New taxon and taxonomy validations" number="4851" />
+## <PRLink number="4851">New taxon and taxonomy validations</PRLink>
 
 New validations were added to the `Taxon` and `Taxonomy` models but are behind the new temporary `extra_taxon_validations` and `extra_taxonomy_validations` preferences.
 
@@ -36,7 +36,7 @@ On top of that, some of your tests may break if you have incorrectly built Taxon
 - As before, if you pass no `taxonomy`, a Taxonomy and its root Taxon will be made.
 - Now, the `parent` will be inferred from the given `taxonomy` or default created Taxonomy. This means, the created Taxon will always be nested (if you want a root Taxon, create a Taxonomy and get its root).
 
-## <PRLink description="Configurable order update attributes class" number="4955" />
+## <PRLink number="4955">Configurable order update attributes class</PRLink>
 
 `Spree::OrderUpdateAttributes` class is no longer hard-coded. That will grant you flexibility if you need to store additional attributes during checkout.
 
@@ -65,7 +65,7 @@ module MyStore
 end
 ```
 
-## <PRLink description="Configure allowed ransackable scopes" number="4956" />
+## <PRLink number="4956">Configure allowed ransackable scopes</PRLink>
 
 We already had allowed ransackable attributes and associations to configure [authorization on Ransack](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#authorization-allowlistingdenylisting). We added the missing `allowed_ransackable_scopes` piece, allowing you to modify the defaults without overriding the `.ransack_scopes` method:
 
@@ -73,19 +73,19 @@ We already had allowed ransackable attributes and associations to configure [aut
 Spree::Product.allowed_ransackable_scopes.concat([:new_scope])
 ```
 
-## <PRLink description="Improvements for the risk analysis report" number="4883" />
+## <PRLink number="4883">Improvements for the risk analysis report</PRLink>
 
 The payment risk analysis summary rendered for orders considered dangerous now contains information for all the associated payments instead of only considering the last one.
 
-## <PRLink description="Easily change from frontend to admin view for an order" number="4886" />
+## <PRLink number="4886">Easily change from frontend to admin view for an order</PRLink>
 
 That's a small quality of life improvement. If you're checking out an order in the storefront, you can now prepend `/admin` to the route and land in the admin panel counterpart. Very helpful during development and testing.
 
-## <PRLink description="All-encompassing update task" number="4957" />
+## <PRLink number="4957">All-encompassing update task</PRLink>
 
 Before, running `bin/rails solidus:update` would only generate the initializer to [update default Solidus preferences](../getting-started/upgrading-solidus#updating-preferences]). Now, it'll also copy the new migration files to your host application. Remember, you'll still need to check and run them by yourself.
 
-## <PRLink description="Deprecate promotions with an `any` policy" number="4991" />
+## <PRLink number="4991">Deprecate promotions with an `any` policy</PRLink>
 
 Actually, promotions with a `match_policy` of `any` were deprecated on v3.2. We forgot to add a deprecation warning, so you may only realize it now.
 
@@ -97,10 +97,10 @@ bin/rake solidus:split_promotions_with_any_match_policy
 
 That will create separate promotions for each of the rules of your promotions with `any` match policy, which should have the same outcome for customers.
 
-## <PRLink description="Deprecation of payment offsets" number="5008" />
+## <PRLink number="5008">Deprecation of payment offsets</PRLink>
 
 That's just some dangling code removal, as payment offsets (the old refund system) have not been used on Solidus for a long time. You must move entirely to the well-established refund system if you're still using them.
 
-## <PRLink description="Deprecated `#line_item_shipment_price`" number="4876" />
+## <PRLink number="4876">Deprecated `#line_item_shipment_price`</PRLink>
 
 The `Admin::OrdersHelper#line_item_shipment_price` method has been deprecated. You can use the equivalent `Spree::LineItem#display_amount` instead.

--- a/versioned_docs/version-4.0/upgrading-solidus/v3.3.mdx
+++ b/versioned_docs/version-4.0/upgrading-solidus/v3.3.mdx
@@ -13,11 +13,11 @@ New year, new Solidus release! This time, we acknowledge our [new policy around 
 
 Before getting hands-on, please review our generic [upgrade guides](/getting-started/upgrading-solidus.mdx). You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.3/CHANGELOG.md) in our repository.
 
-## <PRLink description="Added support for Ruby v3.2" number="4817" />
+## <PRLink number="4817">Added support for Ruby v3.2</PRLink>
 
 Solidus v3.3 comes with support for the recently released v3.2 of Ruby. You can safely upgrade to it without Solidus getting in your way.
 
-## <PRLink description="Removed support for Ruby v2.5" number="4845" />
+## <PRLink number="4845">Removed support for Ruby v2.5</PRLink>
 
 With v3.3, Solidus performs a long-due cleanup of its codebase, removing support for EOL's Ruby versions v2.5 & v2.6. If you're on Solidus v3.2 and you want to upgrade to v3.3:
 
@@ -25,21 +25,21 @@ With v3.3, Solidus performs a long-due cleanup of its codebase, removing support
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Ruby v2.6" number="4848" />
+## <PRLink number="4848">Removed support for Ruby v2.6</PRLink>
 
 Solidus v3.3 no longer supports Ruby v2.6, which reached the EOL status. You'll need to:
 
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Rails v5.2" number="4850" />
+## <PRLink number="4850">Removed support for Rails v5.2</PRLink>
 
 Rails v5.2 (EOL) support has been removed from Solidus v3.3:
 
 - Update your Solidus v3.2 store to Rails v6.0.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Support for the new Colorado delivery fee" number="4491" />
+## <PRLink number="4491">Support for the new Colorado delivery fee</PRLink>
 
 We've updated our taxation system to support the new [Colorado retail delivery fee](https://tax.colorado.gov/retail-delivery-fee).
 Please, check [the corresponding guide page][how-to-setup-colorado-delivery-fee] to setup
@@ -47,19 +47,19 @@ this new tax on your store.
 
 [how-to-setup-colorado-delivery-fee]: ../how-tos/how-to-setup-colorado-delivery-fee
 
-## <PRLink description="Deprecate discriminatory wording for Ransack methods" number="4853" />
+## <PRLink number="4853">Deprecate discriminatory wording for Ransack methods</PRLink>
 
 We're deprecating `.whitelisted_ransackable_attributes` & `.whitelisted_ransackable_associations` in favor of `.allowed_ransackable_attributes` & `.allowed_ransackable_associations`, respectively. The old terms won't be available on the next major.
 
-## <PRLink description="Version upgraded for packaged underscore.js" number="4660" />
+## <PRLink number="4660">Version upgraded for packaged underscore.js</PRLink>
 
 We've upgraded the packaged version of [underscore.js](https://underscorejs.org/) from v1.8.3 to v1.13.6. In case you were using it, check compatibility.
 
-## <PRLink description="Deprecated #mails_from preference" number="4712" />
+## <PRLink number="4712">Deprecated #mails_from preference</PRLink>
 
 We've deprecated the `#mails_from` preference, as it wasn't used in the Solidus codebase anymore. Make sure you aren't using it for anything else. Otherwise, the expected way to handle the default `From:` field for transactional emails is the `Spree::Store#mail_from_address` attribute.
 
-## <PRLink description="Store static preferences using string class names" number="4858" />
+## <PRLink number="4858">Store static preferences using string class names</PRLink>
 
 It's no longer necessary to wrap the definition of static preferences within a `.to_prepare` block to avoid [referencing a constant on an initializer](https://guides.rubyonrails.org/v6.1.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots).
 
@@ -86,7 +86,7 @@ Spree::Config.static_model_preferences.add(
 )
 ```
 
-## <PRLink description="Configurable promotion adjuster" number="4460" />
+## <PRLink number="4460">Configurable promotion adjuster</PRLink>
 
 You can now change what the default promotion adjuster does. Configure the `Spree::Config.promotion_adjuster_class`
 preference with a class that takes the order on initialization and responds to the `#call` method.
@@ -95,7 +95,7 @@ Read [the corresponding how-to][how-to-use-a-custom-promotion-adjuster] for more
 
 [how-to-use-a-custom-promotion-adjuster]: ../how-tos/how-to-use-a-custom-promotion-adjuster
 
-## <PRLink description="Configurable algorithm to prioritize store credits" number="4677" />
+## <PRLink number="4677">Configurable algorithm to prioritize store credits</PRLink>
 
 Before v3.3, store credits were always sorted by the priority of their type. Now you can change
 that behavior by configuring the `Spree::Config.store_credit_prioritizer_class` preference with
@@ -124,19 +124,19 @@ module MyStore
 end
 ```
 
-## <PRLink description="Allow shipping category on variants" number="4739" />
+## <PRLink number="4739">Allow shipping category on variants</PRLink>
 
 It was already possible for a variant to have a different tax category than its product. Now, that's also true for the shipping category.
 
-## <PRLink description="Default implementation for PaymentMethod#try_void" number="4843" />
+## <PRLink number="4843">Default implementation for PaymentMethod#try_void</PRLink>
 
 When adding a new payment integration, it was required to implement the `PaymentMethod#try_void` method. However, it turned out that the logic was always very similar. We now provide a default implementation that would be enough in most situations.
 
-## <PRLink description="Improved bogus credit card voiding" number="4861" />
+## <PRLink number="4861">Improved bogus credit card voiding</PRLink>
 
 Before this change, all attempts to void a payment with this testing payment method in the admin panel were successful. It's now possible to simulate a failure by trying to cancel an order with a captured payment.
 
-## <PRLink description="Variant and product autocomplete functions flexibility with Ransack" number="4767" />
+## <PRLink number="4767">Variant and product autocomplete functions flexibility with Ransack</PRLink>
 
 It's now possible to customize the autocompletion for variants and products on the backend via a callback returning a Ransack query. E.x.:
 
@@ -152,6 +152,6 @@ $('#product-dropdown').productAutocomplete({
 })
 ```
 
-## <PRLink description="Add available in product's Ransack scopes" number="4852" />
+## <PRLink number="4852">Add available in product's Ransack scopes</PRLink>
 
 `.available` is now available to be used as a [Ransack scope](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#using-scopesclass-methods) in `Spree::Product`

--- a/versioned_docs/version-4.0/upgrading-solidus/v3.4.mdx
+++ b/versioned_docs/version-4.0/upgrading-solidus/v3.4.mdx
@@ -13,7 +13,7 @@ This is a slimmer release, but a very important one as it'll be the last on the 
 
 Please, remember to review our generic [upgrade guides](/getting-started/upgrading-solidus.mdx) and run the `bin/rails g solidus:update` task. You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.4/CHANGELOG.md) in our repository.
 
-## <PRLink description="New taxon and taxonomy validations" number="4851" />
+## <PRLink number="4851">New taxon and taxonomy validations</PRLink>
 
 New validations were added to the `Taxon` and `Taxonomy` models but are behind the new temporary `extra_taxon_validations` and `extra_taxonomy_validations` preferences.
 
@@ -36,7 +36,7 @@ On top of that, some of your tests may break if you have incorrectly built Taxon
 - As before, if you pass no `taxonomy`, a Taxonomy and its root Taxon will be made.
 - Now, the `parent` will be inferred from the given `taxonomy` or default created Taxonomy. This means, the created Taxon will always be nested (if you want a root Taxon, create a Taxonomy and get its root).
 
-## <PRLink description="Configurable order update attributes class" number="4955" />
+## <PRLink number="4955">Configurable order update attributes class</PRLink>
 
 `Spree::OrderUpdateAttributes` class is no longer hard-coded. That will grant you flexibility if you need to store additional attributes during checkout.
 
@@ -65,7 +65,7 @@ module MyStore
 end
 ```
 
-## <PRLink description="Configure allowed ransackable scopes" number="4956" />
+## <PRLink number="4956">Configure allowed ransackable scopes</PRLink>
 
 We already had allowed ransackable attributes and associations to configure [authorization on Ransack](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#authorization-allowlistingdenylisting). We added the missing `allowed_ransackable_scopes` piece, allowing you to modify the defaults without overriding the `.ransack_scopes` method:
 
@@ -73,19 +73,19 @@ We already had allowed ransackable attributes and associations to configure [aut
 Spree::Product.allowed_ransackable_scopes.concat([:new_scope])
 ```
 
-## <PRLink description="Improvements for the risk analysis report" number="4883" />
+## <PRLink number="4883">Improvements for the risk analysis report</PRLink>
 
 The payment risk analysis summary rendered for orders considered dangerous now contains information for all the associated payments instead of only considering the last one.
 
-## <PRLink description="Easily change from frontend to admin view for an order" number="4886" />
+## <PRLink number="4886">Easily change from frontend to admin view for an order</PRLink>
 
 That's a small quality of life improvement. If you're checking out an order in the storefront, you can now prepend `/admin` to the route and land in the admin panel counterpart. Very helpful during development and testing.
 
-## <PRLink description="All-encompassing update task" number="4957" />
+## <PRLink number="4957">All-encompassing update task</PRLink>
 
 Before, running `bin/rails solidus:update` would only generate the initializer to [update default Solidus preferences](../getting-started/upgrading-solidus#updating-preferences]). Now, it'll also copy the new migration files to your host application. Remember, you'll still need to check and run them by yourself.
 
-## <PRLink description="Deprecate promotions with an `any` policy" number="4991" />
+## <PRLink number="4991">Deprecate promotions with an `any` policy</PRLink>
 
 Actually, promotions with a `match_policy` of `any` were deprecated on v3.2. We forgot to add a deprecation warning, so you may only realize it now.
 
@@ -97,10 +97,10 @@ bin/rake solidus:split_promotions_with_any_match_policy
 
 That will create separate promotions for each of the rules of your promotions with `any` match policy, which should have the same outcome for customers.
 
-## <PRLink description="Deprecation of payment offsets" number="5008" />
+## <PRLink number="5008">Deprecation of payment offsets</PRLink>
 
 That's just some dangling code removal, as payment offsets (the old refund system) have not been used on Solidus for a long time. You must move entirely to the well-established refund system if you're still using them.
 
-## <PRLink description="Deprecated `#line_item_shipment_price`" number="4876" />
+## <PRLink number="4876">Deprecated `#line_item_shipment_price`</PRLink>
 
 The `Admin::OrdersHelper#line_item_shipment_price` method has been deprecated. You can use the equivalent `Spree::LineItem#display_amount` instead.

--- a/versioned_docs/version-4.0/upgrading-solidus/v4.0.mdx
+++ b/versioned_docs/version-4.0/upgrading-solidus/v4.0.mdx
@@ -36,7 +36,7 @@ Here's a list of things you should take care of.
 
 ## Changes/Removals without deprecation
 
-## <PRLink description="Removed support for Rails < 7 & Ruby < 3" number="5012" />
+## <PRLink number="5012">Removed support for Rails < 7 & Ruby < 3</PRLink>
 
 To have Solidus ready for what comes next, we need everyone to use at least Rails 7. That's because we have a plan to
 switch the Admin Panel to the Hotwire stack, which is now the default in the Rails world.
@@ -50,7 +50,7 @@ Rails iteratively before the Solidus major upgrade.
 
 Along with that, we also removed support for older Ruby versions: **you need at least Ruby 3.0 to use Solidus v4.0**.
 
-## <PRLink description="Make option value to variant association unique" number="4146" />
+## <PRLink number="4146">Make option value to variant association unique</PRLink>
 
 The same option value cannot be associated anymore with a given variant multiple times. It's very likely
 that you are not doing this, but this change introduces a new unique index on the `spree_option_values_variants` database table, which is going to fail if you have duplicate records.
@@ -64,26 +64,26 @@ Spree::OptionValuesVariant.select(:variant_id,:option_value_id).group(:variant_i
 
 If the script above returns anything different from `{}`, you need to remove those duplicates.
 
-## <PRLink description="Remove deprecated_address_id column from shipments" number="4379" />
+## <PRLink number="4379">Remove deprecated_address_id column from shipments</PRLink>
 
 We have not used this column since we removed all references to it in 2016. Be sure you are also
 never using it.
 
-## <PRLink description="Remove position column from spree_taxons" number="4754" />
+## <PRLink number="4754">Remove position column from spree_taxons</PRLink>
 
 Apparently, taxons used to be a list in very early versions of Spree, and have then been refactored to be a nested set. Nested sets are strict supersets of lists,
 so the `position` column is entirely unnecessary.
 
 Please, be sure you are never using it, and if you do, just re-add it with a new migration.
 
-## <PRLink description="Remove unused columns from spree_promotion_rules" number="4881" />
+## <PRLink number="4881">Remove unused columns from spree_promotion_rules</PRLink>
 
 We are cleaning up the `spree_promotion_rules` table from useless columns:
 
 - `product_group_id` refers to something that was removed from Spree in version 1.1 (see https://github.com/spree-contrib/spree_product_groups).
 - `code` refers to nothing.
 
-## <PRLink description="Drop unused table promotion_action_line_items" number="4882" />
+## <PRLink number="4882">Drop unused table promotion_action_line_items</PRLink>
 
 There's another table with identical columns that is being referenced in the codebase, `spree_line_item_actions`.
 

--- a/versioned_docs/version-4.1/upgrading-solidus/v3.3.mdx
+++ b/versioned_docs/version-4.1/upgrading-solidus/v3.3.mdx
@@ -13,11 +13,11 @@ New year, new Solidus release! This time, we acknowledge our [new policy around 
 
 Before getting hands-on, please review our generic [upgrade guides](/upgrading-solidus/index.mdx). You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.3/CHANGELOG.md) in our repository.
 
-## <PRLink description="Added support for Ruby v3.2" number="4817" />
+## <PRLink number="4817">Added support for Ruby v3.2</PRLink>
 
 Solidus v3.3 comes with support for the recently released v3.2 of Ruby. You can safely upgrade to it without Solidus getting in your way.
 
-## <PRLink description="Removed support for Ruby v2.5" number="4845" />
+## <PRLink number="4845">Removed support for Ruby v2.5</PRLink>
 
 With v3.3, Solidus performs a long-due cleanup of its codebase, removing support for EOL's Ruby versions v2.5 & v2.6. If you're on Solidus v3.2 and you want to upgrade to v3.3:
 
@@ -25,21 +25,21 @@ With v3.3, Solidus performs a long-due cleanup of its codebase, removing support
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Ruby v2.6" number="4848" />
+## <PRLink number="4848">Removed support for Ruby v2.6</PRLink>
 
 Solidus v3.3 no longer supports Ruby v2.6, which reached the EOL status. You'll need to:
 
 - Update your Solidus v3.2 store to Ruby v2.7.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Removed support for Rails v5.2" number="4850" />
+## <PRLink number="4850">Removed support for Rails v5.2</PRLink>
 
 Rails v5.2 (EOL) support has been removed from Solidus v3.3:
 
 - Update your Solidus v3.2 store to Rails v6.0.
 - Update your Solidus v3.2 store to v3.3.
 
-## <PRLink description="Support for the new Colorado delivery fee" number="4491" />
+## <PRLink number="4491">Support for the new Colorado delivery fee</PRLink>
 
 We've updated our taxation system to support the new [Colorado retail delivery fee](https://tax.colorado.gov/retail-delivery-fee).
 Please, check [the corresponding guide page][how-to-setup-colorado-delivery-fee] to setup
@@ -47,19 +47,19 @@ this new tax on your store.
 
 [how-to-setup-colorado-delivery-fee]: ../how-tos/how-to-setup-colorado-delivery-fee
 
-## <PRLink description="Deprecate discriminatory wording for Ransack methods" number="4853" />
+## <PRLink number="4853">Deprecate discriminatory wording for Ransack methods</PRLink>
 
 We're deprecating `.whitelisted_ransackable_attributes` & `.whitelisted_ransackable_associations` in favor of `.allowed_ransackable_attributes` & `.allowed_ransackable_associations`, respectively. The old terms won't be available on the next major.
 
-## <PRLink description="Version upgraded for packaged underscore.js" number="4660" />
+## <PRLink number="4660">Version upgraded for packaged underscore.js</PRLink>
 
 We've upgraded the packaged version of [underscore.js](https://underscorejs.org/) from v1.8.3 to v1.13.6. In case you were using it, check compatibility.
 
-## <PRLink description="Deprecated #mails_from preference" number="4712" />
+## <PRLink number="4712">Deprecated #mails_from preference</PRLink>
 
 We've deprecated the `#mails_from` preference, as it wasn't used in the Solidus codebase anymore. Make sure you aren't using it for anything else. Otherwise, the expected way to handle the default `From:` field for transactional emails is the `Spree::Store#mail_from_address` attribute.
 
-## <PRLink description="Store static preferences using string class names" number="4858" />
+## <PRLink number="4858">Store static preferences using string class names</PRLink>
 
 It's no longer necessary to wrap the definition of static preferences within a `.to_prepare` block to avoid [referencing a constant on an initializer](https://guides.rubyonrails.org/v6.1.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots).
 
@@ -86,7 +86,7 @@ Spree::Config.static_model_preferences.add(
 )
 ```
 
-## <PRLink description="Configurable promotion adjuster" number="4460" />
+## <PRLink number="4460">Configurable promotion adjuster</PRLink>
 
 You can now change what the default promotion adjuster does. Configure the `Spree::Config.promotion_adjuster_class`
 preference with a class that takes the order on initialization and responds to the `#call` method.
@@ -95,7 +95,7 @@ Read [the corresponding how-to][how-to-use-a-custom-promotion-adjuster] for more
 
 [how-to-use-a-custom-promotion-adjuster]: ../how-tos/how-to-use-a-custom-promotion-adjuster
 
-## <PRLink description="Configurable algorithm to prioritize store credits" number="4677" />
+## <PRLink number="4677">Configurable algorithm to prioritize store credits</PRLink>
 
 Before v3.3, store credits were always sorted by the priority of their type. Now you can change
 that behavior by configuring the `Spree::Config.store_credit_prioritizer_class` preference with
@@ -124,19 +124,19 @@ module MyStore
 end
 ```
 
-## <PRLink description="Allow shipping category on variants" number="4739" />
+## <PRLink number="4739">Allow shipping category on variants</PRLink>
 
 It was already possible for a variant to have a different tax category than its product. Now, that's also true for the shipping category.
 
-## <PRLink description="Default implementation for PaymentMethod#try_void" number="4843" />
+## <PRLink number="4843">Default implementation for PaymentMethod#try_void</PRLink>
 
 When adding a new payment integration, it was required to implement the `PaymentMethod#try_void` method. However, it turned out that the logic was always very similar. We now provide a default implementation that would be enough in most situations.
 
-## <PRLink description="Improved bogus credit card voiding" number="4861" />
+## <PRLink number="4861">Improved bogus credit card voiding</PRLink>
 
 Before this change, all attempts to void a payment with this testing payment method in the admin panel were successful. It's now possible to simulate a failure by trying to cancel an order with a captured payment.
 
-## <PRLink description="Variant and product autocomplete functions flexibility with Ransack" number="4767" />
+## <PRLink number="4767">Variant and product autocomplete functions flexibility with Ransack</PRLink>
 
 It's now possible to customize the autocompletion for variants and products on the backend via a callback returning a Ransack query. E.x.:
 
@@ -152,6 +152,6 @@ $('#product-dropdown').productAutocomplete({
 })
 ```
 
-## <PRLink description="Add available in product's Ransack scopes" number="4852" />
+## <PRLink number="4852">Add available in product's Ransack scopes</PRLink>
 
 `.available` is now available to be used as a [Ransack scope](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#using-scopesclass-methods) in `Spree::Product`

--- a/versioned_docs/version-4.1/upgrading-solidus/v3.4.mdx
+++ b/versioned_docs/version-4.1/upgrading-solidus/v3.4.mdx
@@ -13,7 +13,7 @@ This is a slimmer release, but a very important one as it'll be the last on the 
 
 Please, remember to review our generic [upgrade guides](/upgrading-solidus/index.mdx) and run the `bin/rails g solidus:update` task. You can also check the complete [Changelog](https://github.com/solidusio/solidus/blob/v3.4/CHANGELOG.md) in our repository.
 
-## <PRLink description="New taxon and taxonomy validations" number="4851" />
+## <PRLink number="4851">New taxon and taxonomy validations</PRLink>
 
 New validations were added to the `Taxon` and `Taxonomy` models but are behind the new temporary `extra_taxon_validations` and `extra_taxonomy_validations` preferences.
 
@@ -36,7 +36,7 @@ On top of that, some of your tests may break if you have incorrectly built Taxon
 - As before, if you pass no `taxonomy`, a Taxonomy and its root Taxon will be made.
 - Now, the `parent` will be inferred from the given `taxonomy` or default created Taxonomy. This means, the created Taxon will always be nested (if you want a root Taxon, create a Taxonomy and get its root).
 
-## <PRLink description="Configurable order update attributes class" number="4955" />
+## <PRLink number="4955">Configurable order update attributes class</PRLink>
 
 `Spree::OrderUpdateAttributes` class is no longer hard-coded. That will grant you flexibility if you need to store additional attributes during checkout.
 
@@ -65,7 +65,7 @@ module MyStore
 end
 ```
 
-## <PRLink description="Configure allowed ransackable scopes" number="4956" />
+## <PRLink number="4956">Configure allowed ransackable scopes</PRLink>
 
 We already had allowed ransackable attributes and associations to configure [authorization on Ransack](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#authorization-allowlistingdenylisting). We added the missing `allowed_ransackable_scopes` piece, allowing you to modify the defaults without overriding the `.ransack_scopes` method:
 
@@ -73,19 +73,19 @@ We already had allowed ransackable attributes and associations to configure [aut
 Spree::Product.allowed_ransackable_scopes.concat([:new_scope])
 ```
 
-## <PRLink description="Improvements for the risk analysis report" number="4883" />
+## <PRLink number="4883">Improvements for the risk analysis report</PRLink>
 
 The payment risk analysis summary rendered for orders considered dangerous now contains information for all the associated payments instead of only considering the last one.
 
-## <PRLink description="Easily change from frontend to admin view for an order" number="4886" />
+## <PRLink number="4886">Easily change from frontend to admin view for an order</PRLink>
 
 That's a small quality of life improvement. If you're checking out an order in the storefront, you can now prepend `/admin` to the route and land in the admin panel counterpart. Very helpful during development and testing.
 
-## <PRLink description="All-encompassing update task" number="4957" />
+## <PRLink number="4957">All-encompassing update task</PRLink>
 
 Before, running `bin/rails solidus:update` would only generate the initializer to [update default Solidus preferences](/upgrading-solidus/index.mdx#updating-preferences]). Now, it'll also copy the new migration files to your host application. Remember, you'll still need to check and run them by yourself.
 
-## <PRLink description="Deprecate promotions with an `any` policy" number="4991" />
+## <PRLink number="4991">Deprecate promotions with an `any` policy</PRLink>
 
 Actually, promotions with a `match_policy` of `any` were deprecated on v3.2. We forgot to add a deprecation warning, so you may only realize it now.
 
@@ -97,10 +97,10 @@ bin/rake solidus:split_promotions_with_any_match_policy
 
 That will create separate promotions for each of the rules of your promotions with `any` match policy, which should have the same outcome for customers.
 
-## <PRLink description="Deprecation of payment offsets" number="5008" />
+## <PRLink number="5008">Deprecation of payment offsets</PRLink>
 
 That's just some dangling code removal, as payment offsets (the old refund system) have not been used on Solidus for a long time. You must move entirely to the well-established refund system if you're still using them.
 
-## <PRLink description="Deprecated `#line_item_shipment_price`" number="4876" />
+## <PRLink number="4876">Deprecated `#line_item_shipment_price`</PRLink>
 
 The `Admin::OrdersHelper#line_item_shipment_price` method has been deprecated. You can use the equivalent `Spree::LineItem#display_amount` instead.

--- a/versioned_docs/version-4.1/upgrading-solidus/v4.0.mdx
+++ b/versioned_docs/version-4.1/upgrading-solidus/v4.0.mdx
@@ -36,7 +36,7 @@ Here's a list of things you should take care of.
 
 ## Changes/Removals without deprecation
 
-## <PRLink description="Removed support for Rails < 7 & Ruby < 3" number="5012" />
+## <PRLink number="5012">Removed support for Rails < 7 & Ruby < 3</PRLink>
 
 To have Solidus ready for what comes next, we need everyone to use at least Rails 7. That's because we have a plan to
 switch the Admin Panel to the Hotwire stack, which is now the default in the Rails world.
@@ -50,7 +50,7 @@ Rails iteratively before the Solidus major upgrade.
 
 Along with that, we also removed support for older Ruby versions: **you need at least Ruby 3.0 to use Solidus v4.0**.
 
-## <PRLink description="Make option value to variant association unique" number="4146" />
+## <PRLink number="4146">Make option value to variant association unique</PRLink>
 
 The same option value cannot be associated anymore with a given variant multiple times. It's very likely
 that you are not doing this, but this change introduces a new unique index on the `spree_option_values_variants` database table, which is going to fail if you have duplicate records.
@@ -64,26 +64,26 @@ Spree::OptionValuesVariant.select(:variant_id,:option_value_id).group(:variant_i
 
 If the script above returns anything different from `{}`, you need to remove those duplicates.
 
-## <PRLink description="Remove deprecated_address_id column from shipments" number="4379" />
+## <PRLink number="4379">Remove deprecated_address_id column from shipments</PRLink>
 
 We have not used this column since we removed all references to it in 2016. Be sure you are also
 never using it.
 
-## <PRLink description="Remove position column from spree_taxons" number="4754" />
+## <PRLink number="4754">Remove position column from spree_taxons</PRLink>
 
 Apparently, taxons used to be a list in very early versions of Spree, and have then been refactored to be a nested set. Nested sets are strict supersets of lists,
 so the `position` column is entirely unnecessary.
 
 Please, be sure you are never using it, and if you do, just re-add it with a new migration.
 
-## <PRLink description="Remove unused columns from spree_promotion_rules" number="4881" />
+## <PRLink number="4881">Remove unused columns from spree_promotion_rules</PRLink>
 
 We are cleaning up the `spree_promotion_rules` table from useless columns:
 
 - `product_group_id` refers to something that was removed from Spree in version 1.1 (see https://github.com/spree-contrib/spree_product_groups).
 - `code` refers to nothing.
 
-## <PRLink description="Drop unused table promotion_action_line_items" number="4882" />
+## <PRLink number="4882">Drop unused table promotion_action_line_items</PRLink>
 
 There's another table with identical columns that is being referenced in the codebase, `spree_line_item_actions`.
 

--- a/versioned_docs/version-4.1/upgrading-solidus/v4.1.mdx
+++ b/versioned_docs/version-4.1/upgrading-solidus/v4.1.mdx
@@ -31,7 +31,7 @@ You can also check the complete [Changelog](https://github.com/solidusio/solidus
 
 :::
 
-## <PRLink description="Add a new admin theme" number="5092" />
+## <PRLink number="5092">Add a new admin theme</PRLink>
 
 https://github.com/solidusio/solidus/pull/5092 is the first step towards the new Admin. It introduces a new
 theme, which is a set of colors and styles that can be applied to the Admin.
@@ -42,7 +42,7 @@ To switch to the new theme, you can set the following preference:
 Spree::Backend::Config.theme = 'solidus_admin'
 ```
 
-## <PRLink description="Allow changing the order recalculator" number="5110" />
+## <PRLink number="5110">Allow changing the order recalculator</PRLink>
 
 The `order.recalculate` and `order.recalculator` are introduced as aliases to the now deprecated
 `order.update` and `order.updater` in order to clarify the intention of these methods.
@@ -55,7 +55,7 @@ your own class that inherits from the current OrderUpdater class and set the new
 Spree::Config.order_recalculator_class = 'YourCustomOrderRecalucator'
 ```
 
-## <PRLink description="Remove respond_to :html from Spree::BaseController" number="5158" />
+## <PRLink number="5158">Remove respond_to :html from Spree::BaseController</PRLink>
 
 When we removed the gem `responders` as a core dependency (it still is for backend and api),
 we forgot to move the `respond_to :html` statement from `Spree::BaseController`, which is part
@@ -71,7 +71,7 @@ could be broken if these statements are true together:
 
 If that's the case, you can just add `respond_to :html` in that controller to fix it.
 
-## <PRLink description="Allow lambda in menu item :match_path option and URL" number="5152" />
+## <PRLink number="5152">Allow lambda in menu item :match_path option and URL</PRLink>
 
 This change allows setting a path for a menu item via a lambda executed at runtime. If engines other than Solidus
 would like their route in the main menu, this is how they can do it dynamically without having to hard-code the path.


### PR DESCRIPTION
## Summary

This makes it work with non-docusaurus enabled preview systems and MD renderers.

<img width="1503" alt="image" src="https://github.com/solidusio/edgeguides/assets/1051/f5f446b1-9cc7-4a84-aae6-d41720240ab0">

## Checklist

- [ ] I have verified that the preview environment works correctly.
