### PR TITLE
Fix missing redirects in documentation URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -182,6 +182,14 @@ const config = {
             to: "/upgrading-solidus",
             from: "/getting-started/upgrading-solidus",
           },
+          {
+            to: "/customization/customizing-your-storefront",
+            from: "/developers/customizations/overview",
+          },
+          {
+            to: "/getting-started/installing-solidus",
+            from: "/developers/getting-started/first-time-installation",
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

1. **Customization Guide Redirect**
   - **From**: `/developers/customizations/overview`
   - **To**: `/customization/customizing-your-storefront`
   
2. **Installation Guide Redirect**
   - **From**: `/developers/getting-started/first-time-installation`
   - **To**: `/getting-started/installing-solidus`


ℹ️ More details here: https://github.com/solidusio/solidus/pull/5404#discussion_r1342903497

## Checklist

- [ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [x] I have verified that the preview environment works correctly.

## Test redirect


1. **Customization Guide Redirect**
   - https://rainerd-fix-redirects.edgeguides.pages.dev/developers/customizations/overview
   
2. **Installation Guide Redirect**
   - https://rainerd-fix-redirects.edgeguides.pages.dev/developers/getting-started/first-time-installation