### PR TITLE
docs: ROR website does not start with www

### DIFF
--- a/docs/getting-started/installing-solidus.mdx
+++ b/docs/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.

--- a/versioned_docs/version-3.2/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-3.2/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.

--- a/versioned_docs/version-3.3/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-3.3/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.

--- a/versioned_docs/version-3.4/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-3.4/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.

--- a/versioned_docs/version-4.0/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-4.0/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.

--- a/versioned_docs/version-4.1/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-4.1/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.

--- a/versioned_docs/version-4.2/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-4.2/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.

--- a/versioned_docs/version-4.3/getting-started/installing-solidus.mdx
+++ b/versioned_docs/version-4.3/getting-started/installing-solidus.mdx
@@ -14,7 +14,7 @@ Solidus requires the following software on the host to run properly:
 
 * [Ruby](https://www.ruby-lang.org) interpreter: Solidus always supports the oldest maintained Ruby
 branch.
-* [Rails](https://www.rubyonrails.org): Solidus always supports the oldest maintained Rails version.
+* [Rails](https://rubyonrails.org): Solidus always supports the oldest maintained Rails version.
 * Relational database: the core and the extensions are always tested
 with [MySQL](https://www.mysql.com) and [PostgreSQL](https://www.postgresql.org), but other
 relational databases should work as well.


### PR DESCRIPTION
## Summary

When clicking on the link to the Ruby on Rails site with www today, you get an SSL error. I offer to correct this.

## Checklist

- [x] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [x] I have verified that the preview environment works correctly.
