### PR TITLE
Start Solidus 4.4 upgrade notes

### DIFF
--- a/docs/advanced-solidus/promotions-system.mdx
+++ b/docs/advanced-solidus/promotions-system.mdx
@@ -5,6 +5,13 @@ needs-diataxis-rewrite: true
 
 # Promotions system
 
+:::info
+
+This is documentation for the legacy promotion system that ships with Solidus up until Solidus 5.
+If you want to use the new promotion system, refer to the [documentation on Github](https://github.com/solidusio/solidus/blob/main/promotions/README.md).
+
+:::
+
 ## Architecture overview
 
 Solidus ships with a powerful rule-based promotions system that allows you to grant flexible
@@ -211,9 +218,9 @@ promotion rule instance:
 
 The last step is to register our new promotion rule in an initializer:
 
-```ruby title="config/initializers/promotions.rb"
+```ruby title="config/initializers/spree.rb"
 # ...
-Rails.application.config.spree.promotions.rules << 'AmazingStore::Promotion::Rules::Payment'
+Spree::Config.promotions.rules << 'AmazingStore::Promotion::Rules::Payment'
 ```
 
 When you create a new promotion in the backend, we should now see the _Payment_ promotion rule. For
@@ -319,9 +326,9 @@ for an example of actions with preferences.
 
 Finally, we need to register our action by adding the following to an initializer:
 
-```ruby title="config/initializers/promotions.rb"
+```ruby title="config/initializers/spree.rb"
 # ...
-Rails.application.config.spree.promotions.actions << 'AmazingStore::Promotion::Actions::HalfShipping'
+Spree::Config.promotions.actions << 'AmazingStore::Promotion::Actions::HalfShipping'
 ```
 
 Like before, let's add a human-friendly description:

--- a/docs/getting-started/installing-solidus.mdx
+++ b/docs/getting-started/installing-solidus.mdx
@@ -119,7 +119,7 @@ generated initializer in `config/initializers/spree.rb`.
 The very first line on it will be very similar to this one:
 
 ```ruby
-Spree.load_defaults '4.3'
+Spree.load_defaults '4.4'
 ```
 
 Some of the default values for Solidus preferences depend on the Solidus version. That line makes

--- a/docs/how-tos/how-to-use-a-custom-promotion-adjuster.mdx
+++ b/docs/how-tos/how-to-use-a-custom-promotion-adjuster.mdx
@@ -34,7 +34,7 @@ use, with the corresponding configuration:
 ```ruby title="config/initializers/spree.rb"
 Spree.config do |config|
   # ...
-  config.promotion_adjuster_class = 'MyStore::PromotionAdjuster'
+  config.promotions.order_adjuster_class = 'MyStore::PromotionAdjuster'
 end
 ```
 

--- a/docs/upgrading-solidus/v4.4.mdx
+++ b/docs/upgrading-solidus/v4.4.mdx
@@ -11,4 +11,36 @@ import MinimalRequirements from '@site/src/theme/MinimalRequirements';
 
 Solidus v4.4 is out! 🎉
 
+## <PRLink number="5805">Hello, `solidus_promotions`</PRLink>
+
+A major new development is the release of `solidus_promotions` and `solidus_legacy_promotions`.
+Solidus' promotion system, while very flexible and one of the major selling points of the system,
+has grown over the years and needed a complete overhaul. This overhaul comes with some behavior change
+that reflects our learnings over many years of deploying Spree and Solidus. It comes with performance
+improvements, easier-to-read code and features that were hard or impossible to implement with the legacy
+promotion system (such as stackable discounts).
+
+However, the refactoring introduced changes in behavior to the promotion system, and it turned out to
+be easier to create a new promotion system gem and extract the current one into a gem. The new promotion system,
+[`solidus_promotions`](https://github.com/solidusio/solidus/blob/v4.4/promotions/), will be Solidus' default from
+Solidus 5. The legacy promotion system has been extracted into its own gem, `solidus_legacy_promotions`.
+
+Now, if your store depends on the full `solidus` suite of gems and you are upgrading a store with promotions,
+things should just work. Some of the promotion configuration endpoints have changed, but these will emit friendly
+deprecation messages telling you which changes to make.
+
+If, however, your Gemfile specifies only `solidus_core` and any other gems that might be part of the suite, you *must*
+also add `solidus_legacy_promotions` as a dependency in order for your store to continue to work. Once that is done, your
+store should work as before.
+
+If setting up a new store, we recommend starting out with the new promotion system. Add
+
+```
+gem "solidus_promotions", "~> 4.4"
+```
+
+to your Gemfile and follow the instructions [here](https://github.com/solidusio/solidus/blob/v4.4/promotions/README.md).
+
+If you want to upgrade your store to the new promotion system, follow the instructions [here](https://github.com/solidusio/solidus/blob/v4.4/promotions/MIGRATING.md)
+
 [...]

--- a/docs/upgrading-solidus/v4.4.mdx
+++ b/docs/upgrading-solidus/v4.4.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_position: -4.4
+---
+
+import PRLink from '@site/src/theme/PRLink';
+import MinimalRequirements from '@site/src/theme/MinimalRequirements';
+
+# Solidus v4.4 (tba)
+
+<MinimalRequirements ruby="3.1" rails="7.0" />
+
+Solidus v4.4 is out! 🎉
+
+[...]


### PR DESCRIPTION
## Summary

Starts 4.4 upgrade notes and adds `solidus_promotions` introduction.

## Checklist

- [ ] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [x] I have verified that the preview environment works correctly.
