### PR TITLE
Fix[Docs] Offensive Language (#144)

### DIFF
--- a/policies/community-guidelines.mdx
+++ b/policies/community-guidelines.mdx
@@ -23,6 +23,7 @@ If you believe someone is violating the guidelines, we ask that you report it by
 *   **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This is a comprehensive list of unacceptable behaviors:
     *   Violent threats or language directed against another person.
     *   Discriminatory jokes and language (i.e. insulting or belittling someone for their identity).
+    *   Language that has been superseeded by reasonable social standards (i.e. use master instead of main or reasonable standard instead of sane). 
     *   Posting sexually explicit or violent material.
     *   Posting (or threatening to post) other people's personally identifying information ("doxing").
     *   Personal insults.


### PR DESCRIPTION
Revises some guidelines regarding the usage of technical wording that has been superseeded by social standards: 
- main instead of master
- reasonable instead of sane

## Summary

Aligned community standards to sanction wording that might be considered offensive today. 

## Checklist

- [X] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [X] I have verified that the preview environment works correctly.
