### PR TITLE
Add docs for configurable event subscribers

### DIFF
--- a/docs/customization/subscribing-to-events.mdx
+++ b/docs/customization/subscribing-to-events.mdx
@@ -84,6 +84,29 @@ subscriptions.
 
 :::
 
+### Built-in event subscribers
+
+Solidus comes with built-in event subscribers for some event-driven functionality in the system. For
+example, all transactional emails are initiated through event subscribers.
+
+When the `solidus_core` engine is loaded, all of the built-in event subscribers are loaded from
+`Spree::Config.environment.subscribers`. If you wanted to exclude some of the built-in subscribers
+you could do so from an initializer in your application:
+
+```ruby
+# config/initializers/spree.rb
+
+Spree.config do |config|
+  config.environment.subscribers = [
+    "Spree::OrderCancelMailerSubscriber",
+    "Spree::OrderConfirmationMailerSubscriber",
+    "Spree::OrderInventoryCancellationMailerSubscriber"
+  ]
+end
+```
+
+See `Spree::AppConfiguration` for an up-to-date list of Solidus' built-in subscribers.
+
 ### Custom events
 
 You're free to register your custom events into `Spree::Bus`. However, it's a good practice if you


### PR DESCRIPTION
## Summary

Built-in Solidus event subscribers are now configurable since solidusio/solidus#6234 was merged. The docs added by this pull request help users understand how to add or remove built-in event subscribers in their applications.

## Checklist

- [x] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [ ] I have verified that the preview environment works correctly.
