### PR TITLE
Add installation warning due to Sprockets::Railtie::ManifestNeededError

### DIFF
--- a/docs/getting-started/installing-solidus.mdx
+++ b/docs/getting-started/installing-solidus.mdx
@@ -79,6 +79,27 @@ If you have an existing Ruby on Rails application, installing Solidus is fairly 
 
 ```bash
 $ bundle add solidus
+```
+
+:::info
+
+If you encounter a `Sprockets::Railtie::ManifestNeededError` in the next step, `bin/rails generate`, you may need to do the following due to [a bug in `sprockets-rails`](https://github.com/rails/sprockets-rails/pull/546):
+Add the sprockets manifest into the generated rails app.
+
+:::
+
+```bash
+$ mkdir -p app/assets/config
+$ cat <<MANIFEST > app/assets/config/manifest.js
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+MANIFEST
+```
+
+Run solidus installation wizard.
+
+```bash
 $ bin/rails generate solidus:install
 ```
 


### PR DESCRIPTION
## Summary

Added warning about Sprockets::Railtie::ManifestNeededError and provided instructions to create the sprockets manifest. Similar to https://github.com/solidusio/solidus_starter_frontend/pull/433

<img width="1074" height="737" alt="Screenshot 2026-04-29 at 6 17 40 PM" src="https://github.com/user-attachments/assets/be5d6c04-36cb-4b8f-b1fc-68568a867422" />

## Checklist

- [x] I have followed the [Diátaxis](https://diataxis.fr/) framework in my PR.
- [x] I have verified that the preview environment works correctly.
